### PR TITLE
feat: Order의 상품 정보 필드 OrderItem 으로 분리 및 검증 로직 분리 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
@@ -111,7 +111,7 @@ public class Order extends BaseAuditEntity {
     }
 
     public void delete(UUID userId) {
-        super.softDelete(userId);
+        super.softDelete();
         this.orderItems.forEach(orderItem -> orderItem.delete(userId));
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.domain.entity;
 
+import com.yeoljeong.tripmate.domain.BaseAuditEntity;
 import com.yeoljeong.tripmate.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.exception.BusinessException;
@@ -12,18 +13,13 @@ import org.hibernate.annotations.UuidGenerator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /*
-    순수 도메인 요구사항
-    - 하나의 주문은 하나의 상품만 담을 수 있다.
-    - 주문은 하나의 단위 일정(plan_unit_id)에 종속된다.
-    - 상품 정보는 상품 ID, 상품명, 업체명, 주소(국가 코드, 주, 시), 단가, 스케줄 정보를 스냅샷으로 저장한다.
-    - 주문 시점의 상품 단가는 0 이상이어야 한다.
-    - 주문은 구매할 상품의 수량 정보를 가진다.
-    - 주문 수량은 1개 이상이어야 한다.
-    - 주문은 상품을 사용할 체험 예정일 정보를 가진다.
-    - 체험 예정일은 현재 날짜 이후 또는 당일이어야 한다.
+    순수 도메인 요구사항 (Order)
+    - 주문은 주문자 정보를 가진다.
     - 주문 생성 시 CONFIRMED 상태의 주문을 생성한다.
     - CONFIRMED 상태의 주문은 완료 처리 시 COMPLETED 상태로 변경된다.
     - CONFIRMED 또는 COMPLETED 상태의 주문은 취소 처리 시 CANCELLED 상태로 변경된다.
@@ -33,8 +29,9 @@ import java.util.UUID;
  */
 
 @Entity
+@Table(name = "p_order")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+public class Order extends BaseAuditEntity {
 
     @Id
     @GeneratedValue
@@ -46,70 +43,43 @@ public class Order {
     private UUID userId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "order_status", length = 20, nullable = false)
+    @Column(name = "order_status", length = 30, nullable = false)
     private OrderStatus orderStatus;
-
-    @Column(name = "plan_unit_id", nullable = false)
-    private UUID planUnitId;
-
-    @Embedded
-    private ProductInfo productInfo;
-
-    @Column(nullable = false)
-    private int quantity;
-
-    @Column(name = "experience_date", nullable = false)
-    private LocalDate experienceDate;
 
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
-    @Column(name = "cancel_reason")
+    @Column(name = "cancel_reason", length = 255)
     private String cancelReason;
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
 
     @Builder
-    private Order(UUID userId, OrderStatus orderStatus, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
-                 String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDateTime cancelledAt, String cancelReason) {
+    private Order(UUID userId, OrderStatus orderStatus, LocalDateTime cancelledAt, String cancelReason) {
         this.userId = userId;
         this.orderStatus = orderStatus;
-        this.planUnitId = planUnitId;
-        this.productInfo = ProductInfo.of(productId, productName, price, companyName, country, state, city, scheduleId);
-        this.quantity = quantity;
-        this.experienceDate = experienceDate;
         this.cancelledAt = cancelledAt;
         this.cancelReason = cancelReason;
     }
 
     public static Order create(UUID userId, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
                         String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
-        validateRequiredIds(userId, planUnitId, productId, scheduleId);
-        validateRequiredText(productName);
-        validateRequiredText(companyName);
-        validateRequiredText(country);
-        validateRequiredText(state);
-        validateRequiredText(city);
-        validateQuantity(quantity);
-        validatePrice(price);
-        validateExperienceDate(experienceDate, today);
+        validateRequiredIds(userId);
 
-        return Order.builder()
+        Order order = Order.builder()
                 .userId(userId)
                 .orderStatus(OrderStatus.CONFIRMED)
-                .planUnitId(planUnitId)
-                .productId(productId)
-                .productName(productName)
-                .price(price)
-                .companyName(companyName)
-                .country(country)
-                .state(state)
-                .city(city)
-                .scheduleId(scheduleId)
-                .quantity(quantity)
-                .experienceDate(experienceDate)
                 .cancelledAt(null)
                 .cancelReason(null)
                 .build();
+
+        OrderItem orderItem = OrderItem.create(order, planUnitId, productId, productName, price,
+                companyName, country, state, city, scheduleId, quantity, experienceDate, today);
+
+        order.addOrderItem(orderItem);
+
+        return order;
     }
 
     // CONFIRMED -> COMPLETED
@@ -140,33 +110,27 @@ public class Order {
         this.cancelReason = cancelReason;
     }
 
-    private static void validateQuantity(int quantity) {
-        if (quantity < 1) {
-            throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
-        }
+    public void delete(UUID userId) {
+        super.softDelete(userId);
+        this.orderItems.forEach(orderItem -> orderItem.delete(userId));
     }
 
-    private static void validatePrice(BigDecimal price) {
-        if (price == null || price.compareTo(BigDecimal.ZERO) < 0) {
-            throw new BusinessException(OrderErrorCode.INVALID_PRICE);
+    private void addOrderItem(OrderItem orderItem) {
+        if (orderItem == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_ITEM);
         }
+
+        // 정책에 따라 단건 주문만 허용
+        if (!this.orderItems.isEmpty()) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER_ITEM_COUNT);
+        }
+
+        this.orderItems.add(orderItem);
     }
 
-    private static void validateExperienceDate(LocalDate experienceDate, LocalDate today) {
-        if (experienceDate == null || experienceDate.isBefore(today)) {
-            throw new BusinessException(OrderErrorCode.INVALID_EXPERIENCE_DATE);
-        }
-    }
-
-    private static void validateRequiredIds(UUID userId, UUID planUnitId, UUID productId, UUID scheduleId) {
-        if (userId == null || planUnitId == null || productId == null || scheduleId == null) {
+    private static void validateRequiredIds(UUID userId) {
+        if (userId == null) {
             throw new BusinessException(OrderErrorCode.INVALID_ID_FIELD);
-        }
-    }
-
-    private static void validateRequiredText(String value) {
-        if (value == null || value.isBlank()) {
-            throw new BusinessException(OrderErrorCode.INVALID_TEXT_FIELD);
         }
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
@@ -125,7 +125,11 @@ public class OrderItem extends BaseAuditEntity {
     }
 
     private static void validateRequiredTexts(String productName, String companyName, String country, String state, String city) {
-        if (isBlank(productName) || isBlank(companyName) || isBlank(country) || isBlank(state) || isBlank(city)) {
+        if (isBlank(productName) || productName.length() > 255
+                || isBlank(companyName) || companyName.length() > 100
+                || isBlank(country) || country.length() != 2
+                || isBlank(state) || state.length() > 255
+                || isBlank(city) || city.length() > 255) {
             throw new BusinessException(OrderErrorCode.INVALID_TEXT_FIELD);
         }
     }

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
@@ -91,7 +91,7 @@ public class OrderItem extends BaseAuditEntity {
     }
 
     public void delete(UUID userId) {
-        super.softDelete(userId);
+        super.softDelete();
     }
 
     private static void validateOrder(Order order) {

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
@@ -1,0 +1,136 @@
+package com.yeoljeong.tripmate.domain.entity;
+
+import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.domain.exception.OrderErrorCode;
+import com.yeoljeong.tripmate.exception.BusinessException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/*
+    순수 도메인 요구사항 (OrderItem)
+    - 하나의 주문은 하나 이상의 주문 항목을 가질 수 있지만, 현재 정책상 하나의 주문은 하나의 주문 항목만 담을 수 있다.
+    - 주문 항목은 하나의 주문에 종속된다.
+    - 주문 항목은 하나의 단위 일정(plan_unit_id)에 종속된다.
+    - 상품 정보는 상품 ID, 상품명, 업체명, 주소(국가 코드, 주, 시), 단가, 스케줄 정보를 스냅샷으로 저장한다.
+    - 주문 시점의 상품 단가는 0 이상이어야 한다.
+    - 주문은 구매할 상품의 수량 정보를 가진다.
+    - 주문 수량은 1개 이상이어야 한다.
+    - 주문 항목은 상품을 사용할 체험 예정일 정보를 가진다.
+    - 체험 예정일은 현재 날짜 이후 또는 당일이어야 한다.
+ */
+
+@Getter
+@Entity
+@Table(name = "p_order_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseAuditEntity {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    @Column(nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Column(name = "plan_unit_id", nullable = false)
+    private UUID planUnitId;
+
+    @Embedded
+    private ProductInfo productInfo;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(name = "experience_date", nullable = false)
+    private LocalDate experienceDate;
+
+    @Builder
+    private OrderItem(Order order, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
+                      String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate) {
+        this.order = order;
+        this.planUnitId = planUnitId;
+        this.productInfo = ProductInfo.of(productId, productName, price, companyName, country, state, city, scheduleId);
+        this.quantity = quantity;
+        this.experienceDate = experienceDate;
+    }
+
+    static OrderItem create(Order order, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
+                            String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
+        validateOrder(order);
+        validatePrice(price);
+        validateQuantity(quantity);
+        validateExperienceDate(experienceDate, today);
+        validateRequiredIds(planUnitId, productId, scheduleId);
+        validateRequiredTexts(productName, companyName, country, state, city);
+
+        return OrderItem.builder()
+                .order(order)
+                .planUnitId(planUnitId)
+                .productId(productId)
+                .productName(productName)
+                .price(price)
+                .companyName(companyName)
+                .country(country)
+                .state(state)
+                .city(city)
+                .scheduleId(scheduleId)
+                .quantity(quantity)
+                .experienceDate(experienceDate)
+                .build();
+    }
+
+    public void delete(UUID userId) {
+        super.softDelete(userId);
+    }
+
+    private static void validateOrder(Order order) {
+        if (order == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_ORDER);
+        }
+    }
+
+    private static void validatePrice(BigDecimal price) {
+        if (price == null || price.compareTo(BigDecimal.ZERO) < 0) {
+            throw new BusinessException(OrderErrorCode.INVALID_PRICE);
+        }
+    }
+
+    private static void validateQuantity(int quantity) {
+        if (quantity < 1) {
+            throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
+        }
+    }
+
+    private static void validateExperienceDate(LocalDate experienceDate, LocalDate today) {
+        if (experienceDate == null || experienceDate.isBefore(today)) {
+            throw new BusinessException(OrderErrorCode.INVALID_EXPERIENCE_DATE);
+        }
+    }
+
+    private static void validateRequiredIds(UUID planUnitId, UUID productId, UUID scheduleId) {
+        if (planUnitId == null || productId == null || scheduleId == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_ID_FIELD);
+        }
+    }
+
+    private static void validateRequiredTexts(String productName, String companyName, String country, String state, String city) {
+        if (isBlank(productName) || isBlank(companyName) || isBlank(country) || isBlank(state) || isBlank(city)) {
+            throw new BusinessException(OrderErrorCode.INVALID_TEXT_FIELD);
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
@@ -113,7 +113,7 @@ public class OrderItem extends BaseAuditEntity {
     }
 
     private static void validateExperienceDate(LocalDate experienceDate, LocalDate today) {
-        if (experienceDate == null || experienceDate.isBefore(today)) {
+        if (today == null || experienceDate == null || experienceDate.isBefore(today)) {
             throw new BusinessException(OrderErrorCode.INVALID_EXPERIENCE_DATE);
         }
     }

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/ProductInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/ProductInfo.java
@@ -14,22 +14,22 @@ public class ProductInfo {
     @Column(name = "product_id", nullable = false)
     private UUID productId;
 
-    @Column(name = "product_name", nullable = false)
+    @Column(name = "product_name", length = 255, nullable = false)
     private String productName;
 
     @Column(nullable = false)
     private BigDecimal price;
 
-    @Column(name = "company_name", nullable = false)
+    @Column(name = "company_name", length = 100, nullable = false)
     private String companyName;
 
-    @Column(nullable = false)
+    @Column(length = 2, nullable = false)
     private String country;
 
-    @Column(nullable = false)
+    @Column(length = 255, nullable = false)
     private String state;
 
-    @Column(nullable = false)
+    @Column(length = 255, nullable = false)
     private String city;
 
     @Column(name = "schedule_id", nullable = false)

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/OrderErrorCode.java
@@ -15,7 +15,11 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격이 유효하지 않습니다."),
     INVALID_EXPERIENCE_DATE(HttpStatus.BAD_REQUEST, "체험 예정일이 유효하지 않습니다."),
     INVALID_ID_FIELD(HttpStatus.BAD_REQUEST, "ID 필드 값이 유효하지 않습니다."),
-    INVALID_TEXT_FIELD(HttpStatus.BAD_REQUEST, "필드 값이 유효하지 않습니다.");
+    INVALID_TEXT_FIELD(HttpStatus.BAD_REQUEST, "필드 값이 유효하지 않습니다."),
+    INVALID_ORDER(HttpStatus.BAD_REQUEST, "주문이 유효하지 않습니다."),
+    INVALID_PRODUCT_INFO(HttpStatus.BAD_REQUEST, "상품 정보가 유효하지 않습니다."),
+    INVALID_ORDER_ITEM(HttpStatus.BAD_REQUEST, "주문 항목이 유효하지 않습니다."),
+    INVALID_ORDER_ITEM_COUNT(HttpStatus.BAD_REQUEST, "주문 항목은 주문 하나 당 한 건만 존재해야 합니다.");
 
     private final HttpStatus status;
     private final String description;


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 도메인의 상품 관련 정보를 `OrderItem`으로 분리하였습니다.
  - Order는 주문의 전반적인 정보(userId, orderStatus, cancelledAt, cancelReason) 담습니다.
  - OrderItem은 주문한 상품의 정보(productId, productName, price, companyName, country, state, city, scheduleIdscheduleId)와 상품에 관련된 정보(planUnitId, quantity, experienceDate)를 담습니다.
  - 상품 정보는 ProductInfo라는 VO로 저장되며, 주문 당시 상품 정보를 스냅샷하여 저장합니다.
- 현재 정책 상 하나의 주문에는 하나의 상품만 담을 수 있도록 하되, 추후 확정을 고려하여 Order와 OrderItem을 1:N 관계로 구성하였습니다.
- 기존에 Order에서 진행하던 검증 로직을 엔티티가 분리됨에 따라 각 필드를 보유한 엔티티에서 검증하도록 변경하였습니다.
- 엔티티의 감사 정보를 추가하기 위해 Order와 OrderItem이 BaseAuditEntity를 상속하도록 구성하였습니다.  

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- Order에서 productInfo, quantity, planUnitId, experienceDate를 제거하여 OrderItem에 구성하였습니다.
- Order 생성 메서드에서 OrderItem을 생성하여 추가하도록 수정했습니다.
- 단건 상품 주문 정책을 유지하기 위해 이미 주문 항목이 존재하는 경우 예외를 발생시키는 검증 로직을 추가하였습니다.
- Order와 OrderItem에 soft delete 처리를 위한 delete() 메서드를 추가하였습니다. 

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 현재 정책 상 하나의 주문은 하나의 상품만 허용하나, 확장을 고려하여 Order와 OrderItem을 분리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 주문이 단일 스냅샷에서 주문/주문항목(부모/자식) 구조로 개편되어 유연성 향상
  * 주문 삭제 시 연관 주문항목까지 함께 소프트 삭제 처리

* **New Features**
  * 주문항목(개별 아이템) 엔티티 도입으로 항목별 관리 가능
  * 항목 수준의 엄격한 유효성 검사 도입 및 관련 오류 유형 4종 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->