### PR TITLE
Feat: country 필드 Enum으로 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/Order.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.domain.entity;
 
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.domain.enums.Country;
 import com.yeoljeong.tripmate.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.exception.BusinessException;
@@ -64,7 +65,7 @@ public class Order extends BaseAuditEntity {
     }
 
     public static Order create(UUID userId, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
-                        String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
+                               Country country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
         validateRequiredIds(userId);
 
         Order order = Order.builder()

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/OrderItem.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.domain.entity;
 
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.domain.enums.Country;
 import com.yeoljeong.tripmate.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import jakarta.persistence.*;
@@ -57,7 +58,7 @@ public class OrderItem extends BaseAuditEntity {
 
     @Builder
     private OrderItem(Order order, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
-                      String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate) {
+                      Country country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate) {
         this.order = order;
         this.planUnitId = planUnitId;
         this.productInfo = ProductInfo.of(productId, productName, price, companyName, country, state, city, scheduleId);
@@ -66,13 +67,14 @@ public class OrderItem extends BaseAuditEntity {
     }
 
     static OrderItem create(Order order, UUID planUnitId, UUID productId, String productName, BigDecimal price, String companyName,
-                            String country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
+                            Country country, String state, String city, UUID scheduleId, int quantity, LocalDate experienceDate, LocalDate today) {
         validateOrder(order);
         validatePrice(price);
+        validateCountry(country);
         validateQuantity(quantity);
         validateExperienceDate(experienceDate, today);
         validateRequiredIds(planUnitId, productId, scheduleId);
-        validateRequiredTexts(productName, companyName, country, state, city);
+        validateRequiredTexts(productName, companyName, state, city);
 
         return OrderItem.builder()
                 .order(order)
@@ -106,6 +108,12 @@ public class OrderItem extends BaseAuditEntity {
         }
     }
 
+    private static void validateCountry(Country country) {
+        if (country == null) {
+            throw new BusinessException(OrderErrorCode.INVALID_COUNTRY);
+        }
+    }
+
     private static void validateQuantity(int quantity) {
         if (quantity < 1) {
             throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
@@ -124,10 +132,9 @@ public class OrderItem extends BaseAuditEntity {
         }
     }
 
-    private static void validateRequiredTexts(String productName, String companyName, String country, String state, String city) {
+    private static void validateRequiredTexts(String productName, String companyName, String state, String city) {
         if (isBlank(productName) || productName.length() > 255
                 || isBlank(companyName) || companyName.length() > 100
-                || isBlank(country) || country.length() != 2
                 || isBlank(state) || state.length() > 255
                 || isBlank(city) || city.length() > 255) {
             throw new BusinessException(OrderErrorCode.INVALID_TEXT_FIELD);

--- a/src/main/java/com/yeoljeong/tripmate/domain/entity/ProductInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/entity/ProductInfo.java
@@ -1,7 +1,10 @@
 package com.yeoljeong.tripmate.domain.entity;
 
+import com.yeoljeong.tripmate.domain.enums.Country;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -23,8 +26,9 @@ public class ProductInfo {
     @Column(name = "company_name", length = 100, nullable = false)
     private String companyName;
 
+    @Enumerated(EnumType.STRING)
     @Column(length = 2, nullable = false)
-    private String country;
+    private Country country;
 
     @Column(length = 255, nullable = false)
     private String state;
@@ -36,7 +40,7 @@ public class ProductInfo {
     private UUID scheduleId;
 
     protected ProductInfo(UUID productId, String productName, BigDecimal price, String companyName,
-                          String country, String state, String city, UUID scheduleId) {
+                          Country country, String state, String city, UUID scheduleId) {
         this.productId = productId;
         this.productName = productName;
         this.price = price;
@@ -48,7 +52,7 @@ public class ProductInfo {
     }
 
     public static ProductInfo of(UUID productId, String productName, BigDecimal price, String companyName,
-                                 String country, String state, String city, UUID scheduleId) {
+                                 Country country, String state, String city, UUID scheduleId) {
         return new ProductInfo(productId, productName, price, companyName, country, state, city, scheduleId);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/domain/enums/Country.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/enums/Country.java
@@ -1,0 +1,6 @@
+package com.yeoljeong.tripmate.domain.enums;
+
+public enum Country {
+    KR,
+    JP
+}

--- a/src/main/java/com/yeoljeong/tripmate/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/domain/exception/OrderErrorCode.java
@@ -13,6 +13,7 @@ public enum OrderErrorCode implements ErrorCode {
     INVALID_CANCEL_REASON(HttpStatus.BAD_REQUEST, "취소 사유가 유효하지 않습니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "수량이 유효하지 않습니다."),
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "가격이 유효하지 않습니다."),
+    INVALID_COUNTRY(HttpStatus.BAD_REQUEST, "국가 코드가 유효하지 않습니다."),
     INVALID_EXPERIENCE_DATE(HttpStatus.BAD_REQUEST, "체험 예정일이 유효하지 않습니다."),
     INVALID_ID_FIELD(HttpStatus.BAD_REQUEST, "ID 필드 값이 유효하지 않습니다."),
     INVALID_TEXT_FIELD(HttpStatus.BAD_REQUEST, "필드 값이 유효하지 않습니다."),


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 상품 스냅샷에 저장되는 국가 코드(country) 필드를 Country Enum으로 관리하도록 변경했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- Country Enum을 추가했습니다. (현재는 KR, JP로만 구성)
- ProductInfo의 country 필드 타입을 String에서 Country로 변경했습니다.
- country에 @Enumerated(EnumType.STRING)을 적용하여 DB에 Enum 이름이 문자열로 저장되도록 수정했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- country는 상품 스냅샷 정보이므로 상품 도메인에서 사용하는 국가 코드 타입과 동일하게 관리합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 국가 선택이 이제 사전 정의된 국가(한국, 일본)로 제한됩니다.
  * 유효하지 않은 국가 정보 입력에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->