### PR TITLE
Feat: 주문 단건, 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/GetOrderListResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/GetOrderListResult.java
@@ -1,0 +1,43 @@
+package com.yeoljeong.tripmate.order.application.dto.result;
+
+import com.yeoljeong.tripmate.order.domain.model.Order;
+import com.yeoljeong.tripmate.order.domain.model.OrderItem;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+public record GetOrderListResult(
+        UUID orderId,
+        UUID userId,
+        String orderStatus,
+        String productName,
+        Integer totalQuantity,
+        BigDecimal totalPrice,
+        LocalDate experienceDate
+) {
+    public static GetOrderListResult from(Order order) {
+        OrderItem firstOrderItem = order.getOrderItems().get(0);
+
+        int totalQuantity = order.getOrderItems().stream()
+                .mapToInt(OrderItem::getQuantity)
+                .sum();
+
+        BigDecimal totalPrice = order.getOrderItems().stream()
+                .map(orderItem -> orderItem.getProductInfo().getPrice()
+                        .multiply(BigDecimal.valueOf(orderItem.getQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return GetOrderListResult.builder()
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .orderStatus(order.getOrderStatus().name())
+                .productName(firstOrderItem.getProductInfo().getProductName())
+                .totalQuantity(totalQuantity)
+                .totalPrice(totalPrice)
+                .experienceDate(firstOrderItem.getExperienceDate())
+                .build();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/GetOrderListResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/GetOrderListResult.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Builder
@@ -19,13 +20,17 @@ public record GetOrderListResult(
         LocalDate experienceDate
 ) {
     public static GetOrderListResult from(Order order) {
-        OrderItem firstOrderItem = order.getOrderItems().get(0);
+        List<OrderItem> orderItems = order.getOrderItems();
+        if (orderItems == null || orderItems.isEmpty()) {
+                throw new IllegalStateException("Order has no items. orderId=" + order.getId());
+            }
+        OrderItem firstOrderItem = orderItems.get(0);
 
-        int totalQuantity = order.getOrderItems().stream()
+        int totalQuantity = orderItems.stream()
                 .mapToInt(OrderItem::getQuantity)
                 .sum();
 
-        BigDecimal totalPrice = order.getOrderItems().stream()
+        BigDecimal totalPrice = orderItems.stream()
                 .map(orderItem -> orderItem.getProductInfo().getPrice()
                         .multiply(BigDecimal.valueOf(orderItem.getQuantity())))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Builder
-public record CreateOrderResult(
+public record OrderResult(
         UUID orderId,
         UUID userId,
         String orderStatus,
@@ -19,8 +19,8 @@ public record CreateOrderResult(
         LocalDateTime cancelledAt,
         String cancelReason
 ) {
-    public static CreateOrderResult from(Order order) {
-        return CreateOrderResult.builder()
+    public static OrderResult from(Order order) {
+        return OrderResult.builder()
                 .orderId(order.getId())
                 .userId(order.getUserId())
                 .orderStatus(order.getOrderStatus().name())

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -3,14 +3,14 @@ package com.yeoljeong.tripmate.order.application.service.command;
 import com.yeoljeong.tripmate.order.application.client.ProductClient;
 import com.yeoljeong.tripmate.order.application.dto.command.CreateOrderCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductCommand;
-import com.yeoljeong.tripmate.order.application.dto.result.CreateOrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
 import com.yeoljeong.tripmate.exception.BusinessException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -23,7 +23,7 @@ public class OrderCommandService {
     private final OrderRepository orderRepository;
     private final ProductClient productClient;
 
-    public CreateOrderResult createOrder(CreateOrderCommand orderCommand) {
+    public OrderResult createOrder(CreateOrderCommand orderCommand) {
 
         if (orderCommand.orderItems() == null || orderCommand.orderItems().size() != 1) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_ITEM_COUNT);
@@ -60,7 +60,7 @@ public class OrderCommandService {
 
         Order savedOrder = orderRepository.save(order);
 
-        return CreateOrderResult.from(savedOrder);
+        return OrderResult.from(savedOrder);
     }
 
     private void validateProductAvailable(String productStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
@@ -1,0 +1,40 @@
+package com.yeoljeong.tripmate.order.application.service.query;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
+import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
+import com.yeoljeong.tripmate.order.domain.model.Order;
+import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryService {
+
+    private final OrderRepository orderRepository;
+
+    // 주문 단건 조회
+    public OrderResult getOrder(UUID orderId, UUID userId) {
+
+        Order order = orderRepository.findByIdAndUserId(orderId, userId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return OrderResult.from(order);
+    }
+
+    // 주문 목록 조회
+    public Slice<GetOrderListResult> getOrders(UUID userId, Pageable pageable) {
+
+        Slice<Order> orders = orderRepository.findAllByUserId(userId, pageable);
+
+        return orders.map(GetOrderListResult::from);
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
@@ -29,7 +29,8 @@ public enum OrderErrorCode implements ErrorCode {
     SCHEDULE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "주문 가능한 일정이 아닙니다."),
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
     ALREADY_ORDERED_PLAN_UNIT(HttpStatus.CONFLICT, "이미 주문한 단위 일정입니다."),
-    REQUIRED_USER_ID(HttpStatus.BAD_REQUEST, "userId는 필수입니다.");
+    REQUIRED_USER_ID(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 이력을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -1,13 +1,22 @@
 package com.yeoljeong.tripmate.order.domain.repository;
 
 import com.yeoljeong.tripmate.order.domain.model.Order;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderRepository {
 
     // 단위 일정에 귀속된 상품을 사용자가 이미 주문한 이력이 있는지
     boolean existsByUserIdAndPlanUnitId(UUID userId, UUID planUnitId);
+
+    // 사용자의 주문 단건 조회
+    Optional<Order> findByIdAndUserId(UUID orderId, UUID userId);
+
+    // 사용자의 주문 목록 조회
+    Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
 
     Order save(Order order);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -1,10 +1,15 @@
 package com.yeoljeong.tripmate.order.infrastructure.persistence.jpa;
 
 import com.yeoljeong.tripmate.order.domain.model.Order;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     boolean existsByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
+    Optional<Order> findByIdAndUserId(UUID orderId, UUID userId);
+    Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -4,8 +4,11 @@ import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
 import com.yeoljeong.tripmate.order.infrastructure.persistence.jpa.OrderJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -17,6 +20,16 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public boolean existsByUserIdAndPlanUnitId(UUID userId, UUID planUnitId) {
         return orderJpaRepository.existsByUserIdAndOrderItems_PlanUnitId(userId, planUnitId);
+    }
+
+    @Override
+    public Optional<Order> findByIdAndUserId(UUID orderId, UUID userId) {
+        return orderJpaRepository.findByIdAndUserId(orderId, userId);
+    }
+
+    @Override
+    public Slice<Order> findAllByUserId(UUID userId, Pageable pageable) {
+        return orderJpaRepository.findAllByUserId(userId, pageable);
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/OrderController.java
@@ -1,12 +1,19 @@
 package com.yeoljeong.tripmate.order.presentation.controller;
 
-import com.yeoljeong.tripmate.order.application.dto.result.CreateOrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
 import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
+import com.yeoljeong.tripmate.order.application.service.query.OrderQueryService;
 import com.yeoljeong.tripmate.order.presentation.dto.request.OrderRequest;
+import com.yeoljeong.tripmate.order.presentation.dto.response.GetOrderSliceResponse;
 import com.yeoljeong.tripmate.order.presentation.dto.response.OrderResponse;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -17,12 +24,28 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderCommandService commandService;
+    private final OrderQueryService queryService;
 
+    // 주문 생성
     @PostMapping
     public ApiResponse<OrderResponse> createOrder(@RequestHeader("X-User-Id") UUID userId, @RequestBody OrderRequest request) {
-        CreateOrderResult result = commandService.createOrder(request.toCommand(userId));
+        OrderResult result = commandService.createOrder(request.toCommand(userId));
 
         return ApiResponse.success(CommonSuccessCode.OK, OrderResponse.from(result));
     }
 
+    // 주문 단건 조회
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderResponse> getOrder(@RequestHeader("X-User-Id") UUID userId, @PathVariable("orderId") UUID orderId) {
+        OrderResult result = queryService.getOrder(orderId, userId);
+        return ApiResponse.success(CommonSuccessCode.OK, OrderResponse.from(result));
+    }
+
+    // 주문 목록 조회
+    @GetMapping
+    public ApiResponse<GetOrderSliceResponse> getOrders(@RequestHeader("X-User-Id") UUID userId,
+                                                        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Slice<GetOrderListResult> result = queryService.getOrders(userId, pageable);
+        return ApiResponse.success(CommonSuccessCode.OK, GetOrderSliceResponse.from(result));
+    }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderListResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderListResponse.java
@@ -1,0 +1,31 @@
+package com.yeoljeong.tripmate.order.presentation.dto.response;
+
+import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+public record GetOrderListResponse(
+        UUID orderId,
+        UUID userId,
+        String orderStatus,
+        String productName,
+        Integer totalQuantity,
+        BigDecimal totalPrice,
+        LocalDate experienceDate
+) {
+    public static GetOrderListResponse from(GetOrderListResult result) {
+        return GetOrderListResponse.builder()
+                .orderId(result.orderId())
+                .userId(result.userId())
+                .orderStatus(result.orderStatus())
+                .productName(result.productName())
+                .totalQuantity(result.totalQuantity())
+                .totalPrice(result.totalPrice())
+                .experienceDate(result.experienceDate())
+                .build();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderSliceResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderSliceResponse.java
@@ -11,9 +11,7 @@ public record GetOrderSliceResponse(
         List<GetOrderListResponse> content,
         int page,
         int size,
-        boolean hasNext,
-        boolean isFirst,
-        boolean isLast
+        boolean hasNext
 ) {
     public static GetOrderSliceResponse from(Slice<GetOrderListResult> result) {
         return GetOrderSliceResponse.builder()
@@ -23,7 +21,6 @@ public record GetOrderSliceResponse(
                 .page(result.getNumber())
                 .size(result.getSize())
                 .hasNext(result.hasNext())
-                .isFirst(result.isFirst())
                 .build();
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderSliceResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/GetOrderSliceResponse.java
@@ -1,0 +1,29 @@
+package com.yeoljeong.tripmate.order.presentation.dto.response;
+
+import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record GetOrderSliceResponse(
+        List<GetOrderListResponse> content,
+        int page,
+        int size,
+        boolean hasNext,
+        boolean isFirst,
+        boolean isLast
+) {
+    public static GetOrderSliceResponse from(Slice<GetOrderListResult> result) {
+        return GetOrderSliceResponse.builder()
+                .content(result.getContent().stream()
+                        .map(GetOrderListResponse::from)
+                        .toList())
+                .page(result.getNumber())
+                .size(result.getSize())
+                .hasNext(result.hasNext())
+                .isFirst(result.isFirst())
+                .build();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/OrderResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/OrderResponse.java
@@ -1,6 +1,6 @@
 package com.yeoljeong.tripmate.order.presentation.dto.response;
 
-import com.yeoljeong.tripmate.order.application.dto.result.CreateOrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -16,7 +16,7 @@ public record OrderResponse(
         LocalDateTime cancelledAt,
         String cancelReason
 ) {
-    public static OrderResponse from(CreateOrderResult result) {
+    public static OrderResponse from(OrderResult result) {
         return new OrderResponse(
                 result.orderId(),
                 result.userId(),
@@ -43,7 +43,7 @@ public record OrderResponse(
             Integer quantity,
             LocalDate experienceDate
     ) {
-        public static OrderItemResponse from(CreateOrderResult.OrderItemResult result) {
+        public static OrderItemResponse from(OrderResult.OrderItemResult result) {
             return new OrderItemResponse(
                     result.orderItemId(),
                     result.planUnitId(),


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 단건 조회 API와 주문 목록 조회 API를 구현했습니다.
- 주문 단건 조회는 orderId와 로그인한 사용자의 userId를 기준으로 조회하여, 다른 사용자의 주문이 조회되지 않도록 구성했습니다.
- 주문 목록 조회는 userId 기준으로 조회하며, Slice 기반 페이지네이션을 적용했습니다.
- 주문 단건 조회 응답 DTO 주문 생성 응답과 동일한 구조를 사용하고, 주문 목록 조회는 목록 화면에 필요한 요약 정보 중심으로 응답하도록 구성했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 주문 단건 조회 API 및 서비스 로직을 추가했습니다.
  - orderId와 userId를 기준으로 주문을 조회합니다.
  - 주문이 존재하지 않는 경우 `NOT FOUND` 예외가 발생합니다.
- 주문 목록 조회 API 및 서비스 로직을 추가했습니다.
  - userId 기준으로 사용자의 주문 목록을 조회합니다.
  - Slice를 사용해 주문 목록을 응답합니다.
- 주문 조회에 필요한 Repository 메서드를 추가했습니다.
  - 주문 단건 조회용 findByIdAndUserId 메서드를 추가했습니다.
  - 주문 목록 조회용 findAllByUserId 메서드를 추가했습니다.
- 주문 목록 조회 응답 DTO를 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 주문 조회 API 추가: 주문 상세를 조회할 수 있습니다.
  * 주문 목록 조회 API 추가: 페이지네이션(기본 페이지 크기 10, 생성일 내림차순)으로 주문 이력을 확인할 수 있습니다.
* **버그 수정/개선**
  * 주문 미조회 시 적절한 404 응답(주문 이력을 찾을 수 없습니다.) 처리 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->