### PR TITLE
Chore: 내부 통신 응답 필드와 응답 형식 변경

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/client/ProductClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/client/ProductClient.java
@@ -5,5 +5,5 @@ import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductComm
 import java.util.UUID;
 
 public interface ProductClient {
-    OrderableProductCommand getSchedule(UUID productId, UUID scheduleId);
+    OrderableProductCommand getSchedule(UUID userId, UUID productId, UUID scheduleId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/client/ProductClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/client/ProductClient.java
@@ -5,5 +5,5 @@ import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductComm
 import java.util.UUID;
 
 public interface ProductClient {
-    OrderableProductCommand getProduct(UUID productId, UUID scheduleId);
+    OrderableProductCommand getSchedule(UUID productId, UUID scheduleId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -32,7 +32,7 @@ public class OrderCommandService {
         CreateOrderCommand.OrderItemCommand orderItemCommand = orderCommand.orderItems().get(0);
 
         // 상품 정보 조회
-        OrderableProductCommand productCommand = productClient.getSchedule(orderItemCommand.productId(), orderItemCommand.scheduleId());
+        OrderableProductCommand productCommand = productClient.getSchedule(orderCommand.userId(), orderItemCommand.productId(), orderItemCommand.scheduleId());
 
         // 이미 구매한 단위 일정의 상품인지 확인
         validateDuplicateOrder(orderCommand.userId(), orderItemCommand.planUnitId());

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -32,7 +32,7 @@ public class OrderCommandService {
         CreateOrderCommand.OrderItemCommand orderItemCommand = orderCommand.orderItems().get(0);
 
         // 상품 정보 조회
-        OrderableProductCommand productCommand = productClient.getProduct(orderItemCommand.productId(), orderItemCommand.scheduleId());
+        OrderableProductCommand productCommand = productClient.getSchedule(orderItemCommand.productId(), orderItemCommand.scheduleId());
 
         // 이미 구매한 단위 일정의 상품인지 확인
         validateDuplicateOrder(orderCommand.userId(), orderItemCommand.planUnitId());

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
@@ -1,11 +1,10 @@
 package com.yeoljeong.tripmate.order.infrastructure.external;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.application.client.ProductClient;
 import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductCommand;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
-import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.infrastructure.external.dto.ProductResponse;
-import com.yeoljeong.tripmate.response.ApiResponse;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
@@ -19,9 +19,9 @@ public class ProductAdapter implements ProductClient {
     private final ProductFeignClient productFeignClient;
 
     @Override
-    public OrderableProductCommand getProduct(UUID productId, UUID scheduleId) {
+    public OrderableProductCommand getSchedule(UUID productId, UUID scheduleId) {
         try {
-            ProductResponse productResponse = productFeignClient.getProduct(productId, scheduleId);
+            ProductResponse productResponse = productFeignClient.getSchedule(productId, scheduleId);
 
             if (productResponse == null) {
                 throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
@@ -21,12 +21,11 @@ public class ProductAdapter implements ProductClient {
     @Override
     public OrderableProductCommand getProduct(UUID productId, UUID scheduleId) {
         try {
-            ApiResponse<ProductResponse> feignResponse = productFeignClient.getProduct(productId, scheduleId);
+            ProductResponse productResponse = productFeignClient.getProduct(productId, scheduleId);
 
-            if (feignResponse == null || feignResponse.getData() == null) {
+            if (productResponse == null) {
                 throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
             }
-            ProductResponse productResponse = feignResponse.getData();
 
             return new OrderableProductCommand(productResponse.productId(), productResponse.productName(),
                     productResponse.country(), productResponse.state(), productResponse.city(), productResponse.price(),

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
@@ -30,7 +30,7 @@ public class ProductAdapter implements ProductClient {
 
             return new OrderableProductCommand(productResponse.productId(), productResponse.productName(),
                     productResponse.country(), productResponse.state(), productResponse.city(), productResponse.price(),
-                    productResponse.productStatus(), productResponse.productScheduleId(), productResponse.date(), productResponse.stock(), productResponse.scheduleStatus());
+                    productResponse.productStatus(), productResponse.scheduleId(), productResponse.date(), productResponse.stock(), productResponse.scheduleStatus());
         } catch (FeignException.NotFound e) {
             throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);
 

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductAdapter.java
@@ -19,9 +19,9 @@ public class ProductAdapter implements ProductClient {
     private final ProductFeignClient productFeignClient;
 
     @Override
-    public OrderableProductCommand getSchedule(UUID productId, UUID scheduleId) {
+    public OrderableProductCommand getSchedule(UUID userId, UUID productId, UUID scheduleId) {
         try {
-            ProductResponse productResponse = productFeignClient.getSchedule(productId, scheduleId);
+            ProductResponse productResponse = productFeignClient.getSchedule(userId.toString(), "USER", productId, scheduleId);
 
             if (productResponse == null) {
                 throw new BusinessException(OrderErrorCode.PRODUCT_NOT_FOUND);

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
@@ -1,7 +1,6 @@
 package com.yeoljeong.tripmate.order.infrastructure.external;
 
 import com.yeoljeong.tripmate.order.infrastructure.external.dto.ProductResponse;
-import com.yeoljeong.tripmate.response.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,5 +10,5 @@ import java.util.UUID;
 @FeignClient(name = "company-service", path = "/internal/products")
 public interface ProductFeignClient {
     @GetMapping("/{productId}/schedules/{scheduleId}")
-    ApiResponse<ProductResponse> getProduct(@PathVariable("productId") UUID productId,@PathVariable("scheduleId") UUID scheduleId);
+    ProductResponse getProduct(@PathVariable("productId") UUID productId,@PathVariable("scheduleId") UUID scheduleId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
@@ -4,11 +4,12 @@ import com.yeoljeong.tripmate.order.infrastructure.external.dto.ProductResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.UUID;
 
 @FeignClient(name = "company-service", path = "/internal/products")
 public interface ProductFeignClient {
     @GetMapping("/{productId}/schedules/{scheduleId}")
-    ProductResponse getSchedule(@PathVariable("productId") UUID productId,@PathVariable("scheduleId") UUID scheduleId);
+    ProductResponse getSchedule(@RequestHeader("X-User-Id") String userId, @RequestHeader("X-User-Role") String userRole, @PathVariable("productId") UUID productId, @PathVariable("scheduleId") UUID scheduleId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/ProductFeignClient.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 @FeignClient(name = "company-service", path = "/internal/products")
 public interface ProductFeignClient {
     @GetMapping("/{productId}/schedules/{scheduleId}")
-    ProductResponse getProduct(@PathVariable("productId") UUID productId,@PathVariable("scheduleId") UUID scheduleId);
+    ProductResponse getSchedule(@PathVariable("productId") UUID productId,@PathVariable("scheduleId") UUID scheduleId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/ProductResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/ProductResponse.java
@@ -2,7 +2,6 @@ package com.yeoljeong.tripmate.order.infrastructure.external.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.UUID;
 
 public record ProductResponse(

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/ProductResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/ProductResponse.java
@@ -13,7 +13,7 @@ public record ProductResponse(
         String city,
         BigDecimal price,
         String productStatus,
-        UUID productScheduleId,
+        UUID scheduleId,
         LocalDate date,
         Integer stock,
         String scheduleStatus


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 상품 조회 API에 대한 내부 통신 시, 응답 필드와 응답 형식이 변경되어 관련된 코드를 수정했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 응답 DTO 필드에서 productScheduleId를 scheduleId로 변경하였습니다.
- 응답 형식을 ApiResponse를 감싸지 않는 형태로 변경하였습니다.
- 내부 통신 요청 메서드 이름 getSchedule()로 변경하였습니다.
- 내부 통신 헤더값으로 userId와 role 추가

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 현재 common 모듈의 UserContextInterceptor에서 헤더 값을 설정하는데, 내부 통신에도 적용되어 임시로 userId와 role를 헤더에 추가하였습니다. 논의 후 internal 경로에서 헤더값이 제외된다면 삭제할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 상품 일정 조회 시 사용자 인증 정보를 추가로 포함하도록 개선했습니다.
  * API 요청 시 사용자 ID와 역할 정보를 헤더에 포함하여 더욱 안전한 데이터 처리가 가능해졌습니다.

* **변경사항**
  * 주문 생성 프로세스에서 상품 일정 조회 방식이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->