### PR TITLE
Feat: 참여 확인 API 호출 로직 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/client/PlanClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/client/PlanClient.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.order.application.client;
+
+import com.yeoljeong.tripmate.order.application.dto.command.ApprovalUserCommand;
+
+import java.util.UUID;
+
+public interface PlanClient {
+    ApprovalUserCommand getPlanParticipation(UUID userId, UUID planUnitId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/command/ApprovalUserCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/command/ApprovalUserCommand.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.order.application.dto.command;
+
+import java.util.UUID;
+
+public record ApprovalUserCommand(
+        UUID planUnitId,
+        UUID userId,
+        String status
+) {}

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -1,6 +1,8 @@
 package com.yeoljeong.tripmate.order.application.service.command;
 
+import com.yeoljeong.tripmate.order.application.client.PlanClient;
 import com.yeoljeong.tripmate.order.application.client.ProductClient;
+import com.yeoljeong.tripmate.order.application.dto.command.ApprovalUserCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.CreateOrderCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductCommand;
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
@@ -22,6 +24,7 @@ public class OrderCommandService {
 
     private final OrderRepository orderRepository;
     private final ProductClient productClient;
+    private final PlanClient planClient;
 
     public OrderResult createOrder(CreateOrderCommand orderCommand) {
 
@@ -30,6 +33,12 @@ public class OrderCommandService {
         }
 
         CreateOrderCommand.OrderItemCommand orderItemCommand = orderCommand.orderItems().get(0);
+
+        // 참여 여부 조회
+        ApprovalUserCommand approvalUserCommand = planClient.getPlanParticipation(orderCommand.userId(), orderItemCommand.planUnitId());
+
+        // 참여 가능 상태인지 검증
+        validateParticipationAvailable(approvalUserCommand.status());
 
         // 상품 정보 조회
         OrderableProductCommand productCommand = productClient.getSchedule(orderCommand.userId(), orderItemCommand.productId(), orderItemCommand.scheduleId());
@@ -60,6 +69,12 @@ public class OrderCommandService {
         Order savedOrder = orderRepository.save(order);
 
         return OrderResult.from(savedOrder);
+    }
+
+    private void validateParticipationAvailable(String participationStatus) {
+        if (!"APPROVAL".equals(participationStatus)) {
+            throw new BusinessException(OrderErrorCode.PLAN_PARTICIPATION_NOT_AVAILABLE);
+        }
     }
 
     private void validateProductAvailable(String productStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
@@ -30,7 +30,10 @@ public enum OrderErrorCode implements ErrorCode {
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
     ALREADY_ORDERED_PLAN_UNIT(HttpStatus.CONFLICT, "이미 주문한 단위 일정입니다."),
     REQUIRED_USER_ID(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 이력을 찾을 수 없습니다.");
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 이력을 찾을 수 없습니다."),
+    PLAN_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "참여 이력을 찾을 수 없습니다."),
+    PLAN_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일정 서비스 호출 에러입니다."),
+    PLAN_PARTICIPATION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "참여되지 않은 일정의 상품은 구매할 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PlanAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PlanAdapter.java
@@ -1,0 +1,37 @@
+package com.yeoljeong.tripmate.order.infrastructure.external;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.application.client.PlanClient;
+import com.yeoljeong.tripmate.order.application.dto.command.ApprovalUserCommand;
+import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
+import com.yeoljeong.tripmate.order.infrastructure.external.dto.PlanParticipationResponse;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PlanAdapter implements PlanClient {
+
+    private final PlanFeignClient planFeignClient;
+
+    @Override
+    public ApprovalUserCommand getPlanParticipation(UUID userId, UUID planUnitId) {
+        try {
+            PlanParticipationResponse planParticipationResponse = planFeignClient.getPlanParticipation(userId.toString(), "USER", planUnitId, userId);
+
+            if (planParticipationResponse == null) {
+                throw new BusinessException(OrderErrorCode.PLAN_PARTICIPATION_NOT_FOUND);
+            }
+
+            return new ApprovalUserCommand(planParticipationResponse.planUnitId(), planParticipationResponse.userId(), planParticipationResponse.status());
+        } catch (FeignException.NotFound e) {
+            throw new BusinessException(OrderErrorCode.PLAN_PARTICIPATION_NOT_FOUND);
+
+        } catch (FeignException e) {
+            throw new BusinessException(OrderErrorCode.PLAN_SERVICE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PlanFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PlanFeignClient.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.order.infrastructure.external;
+
+import com.yeoljeong.tripmate.order.infrastructure.external.dto.PlanParticipationResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.UUID;
+
+@FeignClient(name = "plan-service", path = "/internal/plan-units")
+public interface PlanFeignClient {
+    @GetMapping("/{planUnitId}/participations/users/{userId}")
+    PlanParticipationResponse getPlanParticipation(@RequestHeader("X-User-Id") String headerUserId, @RequestHeader("X-User-Role") String headerUserRole, @PathVariable("planUnitId") UUID planUnitId, @PathVariable("userId") UUID userId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/PlanParticipationResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/PlanParticipationResponse.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.order.infrastructure.external.dto;
+
+import java.util.UUID;
+
+public record PlanParticipationResponse(
+        UUID planUnitId,
+        UUID userId,
+        String status
+) {}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 생성 전 사용자의 일정 참여 승인 여부를 확인하기 위한 내부 통신 API 호출 로직을 추가하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 일정 서비스를 호출하는 FeignClient를 추가했습니다.
- infrastructure 계층에 참여 확인 API의 응답 DTO인 PlanParticipationResponse를 추가하였습니다.
- application 계층에서 필요한 호출 메서드를 정의하고, infrastructure 계층에서 PlanAdapter로 구현하였습니다.
- 서비스 로직에서 참여 확인 API를 호출하는 로직을 추가하고, 사용자의 일정 참여가 APPROVAL 상태인지 검증하는 메서드를 추가하였습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 상품 서비스 내부 통신과 마찬가지로 임시로 userId와 role을 헤더에 추가하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 생성 시 사용자의 플랜 참여 여부를 검증하는 기능 추가. 사용자가 참여하지 않은 플랜의 상품은 구매할 수 없으며, 시도 시 적절한 오류 메시지를 표시합니다.

* **개선사항**
  * 주문 유효성 검사 프로세스 강화로 데이터 무결성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->