### PR TITLE
Fix: 결제 가능 주문 조회 API URL, 응답 수정

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
@@ -18,10 +18,10 @@ public class OrderInternalController {
 
     private final OrderQueryService queryService;
 
-    @GetMapping("{orderId}/payments")
-    public ApiResponse<PayableOrderResponse> getPayableOrder(@RequestHeader("X-User-Id") UUID userId, @PathVariable("orderId") UUID orderId) {
+    @GetMapping("/{orderId}/payment")
+    public PayableOrderResponse getPayableOrder(@PathVariable("orderId") UUID orderId) {
         PayableOrderResult result = queryService.getPayableOrder(orderId);
 
-        return ApiResponse.success(CommonSuccessCode.OK, PayableOrderResponse.from(result));
+        return PayableOrderResponse.from(result);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
@@ -4,10 +4,11 @@ package com.yeoljeong.tripmate.order.presentation.controller.internal;
 import com.yeoljeong.tripmate.order.application.dto.result.PayableOrderResult;
 import com.yeoljeong.tripmate.order.application.service.query.OrderQueryService;
 import com.yeoljeong.tripmate.order.presentation.dto.response.PayableOrderResponse;
-import com.yeoljeong.tripmate.response.ApiResponse;
-import com.yeoljeong.tripmate.response.constants.CommonSuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 결제 가능 주문 조회 API의 URL과 응답 형식을 수정하였습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- API URL의 오타를 수정하였습니다.
  - /internal/orders{orderId}/payments → /internal/orders/{orderId}/payment
- 응답 형식에서 ApiResponse를 제거하고 응답 객체만 넘기도록 수정하였습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 주문 결제 정보 조회 API 엔드포인트가 간편화되었습니다. 불필요한 요청 헤더 요구사항이 제거되었으며, API 응답 구조가 최적화되었습니다. 엔드포인트 경로 형식도 표준화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->