### PR TITLE
Fix: userId 사용 로직 변경

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/OrderServiceApplication.java
+++ b/src/main/java/com/yeoljeong/tripmate/OrderServiceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableJpaAuditing(auditorAwareRef = "userAuditorAware")
 public class OrderServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/external/OrderController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/external/OrderController.java
@@ -1,5 +1,7 @@
 package com.yeoljeong.tripmate.order.presentation.controller.external;
 
+import com.yeoljeong.tripmate.auth.annotation.LoginUser;
+import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
 import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
@@ -28,24 +30,24 @@ public class OrderController {
 
     // 주문 생성
     @PostMapping
-    public ApiResponse<OrderResponse> createOrder(@RequestHeader("X-User-Id") UUID userId, @RequestBody OrderRequest request) {
-        OrderResult result = commandService.createOrder(request.toCommand(userId));
+    public ApiResponse<OrderResponse> createOrder(@LoginUser UserContext userContext, @RequestBody OrderRequest request) {
+        OrderResult result = commandService.createOrder(request.toCommand(userContext.userId()));
 
         return ApiResponse.success(CommonSuccessCode.OK, OrderResponse.from(result));
     }
 
     // 주문 단건 조회
     @GetMapping("/{orderId}")
-    public ApiResponse<OrderResponse> getOrder(@RequestHeader("X-User-Id") UUID userId, @PathVariable("orderId") UUID orderId) {
-        OrderResult result = queryService.getOrder(orderId, userId);
+    public ApiResponse<OrderResponse> getOrder(@LoginUser UserContext userContext, @PathVariable("orderId") UUID orderId) {
+        OrderResult result = queryService.getOrder(orderId, userContext.userId());
         return ApiResponse.success(CommonSuccessCode.OK, OrderResponse.from(result));
     }
 
     // 주문 목록 조회
     @GetMapping
-    public ApiResponse<GetOrderSliceResponse> getOrders(@RequestHeader("X-User-Id") UUID userId,
+    public ApiResponse<GetOrderSliceResponse> getOrders(@LoginUser UserContext userContext,
                                                         @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Slice<GetOrderListResult> result = queryService.getOrders(userId, pageable);
+        Slice<GetOrderListResult> result = queryService.getOrders(userContext.userId(), pageable);
         return ApiResponse.success(CommonSuccessCode.OK, GetOrderSliceResponse.from(result));
     }
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 헤더에서 userId을 바로 받는 대신, 로그인된 사용자의 userId를 사용하는 로직으로 변경했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- OrderController에서 X-User-Id를 받던 부분을 LoginUser 사용 로직으로 변경했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
