### PR TITLE
Feat: 내부 통신용 주문 일정 조회 API 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderPlanResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderPlanResult.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.order.application.dto.result;
+
+import java.util.UUID;
+
+public record OrderPlanResult(
+        UUID orderId,
+        UUID planUnitId
+) { }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
@@ -53,6 +53,10 @@ public class OrderQueryService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
+        if (order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            throw new BusinessException(OrderErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
         return new OrderPlanResult(order.getId(), order.getOrderItems().get(0).getPlanUnitId());
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.order.application.service.query;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.application.dto.result.OrderPlanResult;
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
 import com.yeoljeong.tripmate.order.application.dto.result.PayableOrderResult;
@@ -45,5 +46,12 @@ public class OrderQueryService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         return PayableOrderResult.from(order);
+    }
+
+    public OrderPlanResult getOrderPlan(UUID orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return new OrderPlanResult(order.getId(), order.getOrderItems().get(0).getPlanUnitId());
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
@@ -48,6 +48,7 @@ public class OrderQueryService {
         return PayableOrderResult.from(order);
     }
 
+    // 주문 일정 정보 조회
     public OrderPlanResult getOrderPlan(UUID orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
@@ -31,6 +31,7 @@ public enum OrderErrorCode implements ErrorCode {
     ALREADY_ORDERED_PLAN_UNIT(HttpStatus.CONFLICT, "이미 주문한 단위 일정입니다."),
     REQUIRED_USER_ID(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 이력을 찾을 수 없습니다."),
+    ORDER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 항목을 찾을 수 없습니다."),
     PLAN_PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "참여 이력을 찾을 수 없습니다."),
     PLAN_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일정 서비스 호출 에러입니다."),
     PLAN_PARTICIPATION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "참여되지 않은 일정의 상품은 구매할 수 없습니다."),

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
@@ -1,8 +1,10 @@
 package com.yeoljeong.tripmate.order.presentation.controller.internal;
 
 
+import com.yeoljeong.tripmate.order.application.dto.result.OrderPlanResult;
 import com.yeoljeong.tripmate.order.application.dto.result.PayableOrderResult;
 import com.yeoljeong.tripmate.order.application.service.query.OrderQueryService;
+import com.yeoljeong.tripmate.order.presentation.dto.response.OrderPlanResponse;
 import com.yeoljeong.tripmate.order.presentation.dto.response.PayableOrderResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,5 +26,12 @@ public class OrderInternalController {
         PayableOrderResult result = queryService.getPayableOrder(orderId);
 
         return PayableOrderResponse.from(result);
+    }
+
+    @GetMapping("/{orderId}")
+    public OrderPlanResponse getOrderPlan(@PathVariable("orderId") UUID orderId) {
+        OrderPlanResult result = queryService.getOrderPlan(orderId);
+
+        return new OrderPlanResponse(result.orderId(), result.planUnitId());
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/OrderPlanResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/response/OrderPlanResponse.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.order.presentation.dto.response;
+
+import java.util.UUID;
+
+public record OrderPlanResponse(
+        UUID orderId,
+        UUID planUnitId
+) { }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 일정에서 상태 변경 시 필요한 planUnitId를 반환하는 내부 통신 API를 구현했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- internal Controller에 API 엔드포인트를 추가했습니다.
- OrderPlanResult, OrderPlanResponse를 추가하여 계층별 DTO로 사용했습니다.
- 서비스 로직에서 getOrderPlan()를 추가하여 필요한 정보를 조회하고, 반환하도록 작성했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- 주문의 계획 정보를 조회하는 내부 API 엔드포인트 추가. 주문 ID를 입력받아 해당 주문의 주문 ID와 계획 단위 ID를 반환합니다. 주문과 여행 계획 간의 관계를 조회할 수 있는 기능이 새로 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->