### PR TITLE
Feat: 수신 이벤트 추가 및 주문 취소 로직 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -107,6 +107,10 @@ public class OrderCommandService {
         Order order = orderRepository.findByUserIdAndPlanUnitId(userId, planUnitId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
+        if (order.isCancelled()) {
+            return;
+        }
+
         // TODO: 이벤트 객체에 취소 사유 추가 후 하드코딩 변경
         order.cancel(LocalDateTime.now(), "단순 변심");
 
@@ -129,6 +133,10 @@ public class OrderCommandService {
     public void cancelOrderByPlanUnitParticipantRollback(UUID orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (order.isCancelled()) {
+            return;
+        }
 
         // TODO: 이벤트 객체에 취소 사유 추가 후 하드코딩 변경
         order.cancel(LocalDateTime.now(), "단순 변심");

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.order.application.service.command;
 
+import com.yeoljeong.tripmate.event.OrderCancelledEvent;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.enums.OrderTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -98,6 +100,38 @@ public class OrderCommandService {
         }
 
         order.complete();
+    }
+
+    // 일정 탈퇴 이벤트 수신 후 동작
+    public void cancelOrderByParticipantQuit(UUID userId, UUID planUnitId) {
+        Order order = orderRepository.findByUserIdAndPlanUnitId(userId, planUnitId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // TODO: 이벤트 객체에 취소 사유 추가 후 하드코딩 변경
+        order.cancel(LocalDateTime.now(), "단순 변심");
+
+        OrderCancelledEvent event = new OrderCancelledEvent(
+                UUID.randomUUID(),
+                order.getId(),
+                order.getUserId(),
+                order.getOrderItems().get(0).getPlanUnitId(),
+                order.getOrderItems().get(0).getProductInfo().getProductId(),
+                order.getOrderItems().get(0).getProductInfo().getProductName(),
+                order.getOrderItems().get(0).getProductInfo().getScheduleId(),
+                order.getOrderItems().get(0).getQuantity()
+        );
+
+        // 주문 취소 이벤트 outbox에 저장
+        orderOutboxRecorder.record(OrderTopic.ORDER_CANCELLED_TOPIC, event);
+    }
+
+    // 인원 증가 실패 이벤트 수신 후 동작
+    public void cancelOrderByPlanUnitParticipantRollback(UUID orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // TODO: 이벤트 객체에 취소 사유 추가 후 하드코딩 변경
+        order.cancel(LocalDateTime.now(), "단순 변심");
     }
 
     private void validateParticipationAvailable(String participationStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
@@ -163,4 +163,6 @@ public class Order extends BaseAuditEntity {
     public boolean isCompleted() {
         return this.orderStatus == OrderStatus.COMPLETED;
     }
+
+    public boolean isCancelled() { return this.orderStatus == OrderStatus.CANCELLED; }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -21,5 +21,8 @@ public interface OrderRepository {
     // 주문 단건 조회
     Optional<Order> findById(UUID orderId);
 
+    // userId와 planUnitId로 주문 단건 조회
+    Optional<Order> findByUserIdAndPlanUnitId(UUID userId, UUID planUnitId);
+
     Order save(Order order);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -1,0 +1,79 @@
+package com.yeoljeong.tripmate.order.infrastructure.messaging;
+
+import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
+import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
+import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
+import com.yeoljeong.tripmate.event.enums.PlanTopic;
+import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlanKafkaConsumer {
+
+    private final OrderCommandService commandService;
+
+    @KafkaListener(
+            topics = PlanTopic.PLAN_UNIT_PARTICIPANT_QUIT_TOPIC,
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumePlanUnitParticipantQuit(PlanUnitParticipantQuitEvent event, Acknowledgment acknowledgment) {
+        log.info("[Order] plan.unit.participant.quit 이벤트 수신: planUnitId={}", event.planUnitId());
+
+        try {
+            commandService.cancelOrderByParticipantQuit(event.userId(), event.planUnitId());
+            acknowledgment.acknowledge();
+
+            log.info("[Order] plan.unit.participant.quit 이벤트 처리 성공: userId={}, planUnitId={}", event.userId(), event.planUnitId());
+        } catch (Exception e) {
+            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: userId={}, planUnitId={}, error={}",
+                    event.userId(), event.planUnitId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @KafkaListener(
+            topics = PlanTopic.PLAN_UNIT_PARTICIPANT_ADD_FAILED_TOPIC,
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumePlanUnitAddParticipantFailed(PlanUnitAddParticipantFailedEvent event, Acknowledgment acknowledgment) {
+        log.info("[Order] plan.unit.participant.add.failed 이벤트 수신: orderId={}", event.orderId());
+
+        handleParticipantDeductOrAddFailed(event.orderId(), acknowledgment);
+
+        log.info("[Order] plan.unit.participant.add.failed 이벤트 처리 성공: orderId={}", event.orderId());
+    }
+
+    @KafkaListener(
+            topics = PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_TOPIC,
+            groupId = "${spring.kafka.consumer.group-id}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumePlanUnitDeductParticipant(PlanUnitDeductParticipantEvent event, Acknowledgment acknowledgment) {
+        log.info("[Order] plan.unit.participant.deducted 이벤트 수신: orderId={}", event.orderId());
+
+        handleParticipantDeductOrAddFailed(event.orderId(), acknowledgment);
+
+        log.info("[Order] plan.unit.participant.deducted 이벤트 처리 성공: orderId={}", event.orderId());
+    }
+
+    private void handleParticipantDeductOrAddFailed(UUID orderId, Acknowledgment acknowledgment) {
+        try {
+            commandService.cancelOrderByPlanUnitParticipantRollback(orderId);
+            acknowledgment.acknowledge();
+        } catch (Exception e) {
+            log.error("[Order] PlanUnit 참여자 보상 트랜잭션 이벤트 처리 실패, 재시도 예정: orderId={}, error={}",
+                    orderId, e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -4,7 +4,9 @@ import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import com.yeoljeong.tripmate.event.enums.PlanTopic;
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
+import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -33,6 +35,17 @@ public class PlanKafkaConsumer {
             acknowledgment.acknowledge();
 
             log.info("[Order] plan.unit.participant.quit 이벤트 처리 성공: userId={}, planUnitId={}", event.userId(), event.planUnitId());
+        } catch (BusinessException e) {
+            if (isNonRetryable(e)) {
+                log.warn("[Order] plan.unit.participant.quit 이벤트 처리 스킵: userId={}, planUnitId={}", event.userId(), event.planUnitId(), e);
+
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: userId={}, planUnitId={}, error={}",
+                    event.userId(), event.planUnitId(), e.getMessage(), e);
+            throw e;
         } catch (Exception e) {
             log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: userId={}, planUnitId={}, error={}",
                     event.userId(), event.planUnitId(), e.getMessage(), e);
@@ -70,10 +83,28 @@ public class PlanKafkaConsumer {
         try {
             commandService.cancelOrderByPlanUnitParticipantRollback(orderId);
             acknowledgment.acknowledge();
+        } catch (BusinessException e) {
+            if (isNonRetryable(e)) {
+                log.warn("[Order] PlanUnit 참여자 보상 트랜잭션 이벤트 처리 스킵: orderId={}, ", orderId, e);
+
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            log.error("[Order] PlanUnit 참여자 보상 트랜잭션 이벤트 처리 실패, 재시도 예정: orderId={}, error={}",
+                    orderId, e.getMessage(), e);
+            throw e;
         } catch (Exception e) {
             log.error("[Order] PlanUnit 참여자 보상 트랜잭션 이벤트 처리 실패, 재시도 예정: orderId={}, error={}",
                     orderId, e.getMessage(), e);
             throw e;
         }
+    }
+
+    private boolean isNonRetryable(BusinessException e) {
+        return e.getErrorCode() == OrderErrorCode.ORDER_NOT_FOUND
+                || e.getErrorCode() == OrderErrorCode.INVALID_ORDER_STATUS
+                || e.getErrorCode() == OrderErrorCode.INVALID_CANCELLED_AT
+                || e.getErrorCode() == OrderErrorCode.INVALID_CANCEL_REASON;
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -12,4 +12,5 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     boolean existsByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
     Optional<Order> findByIdAndUserId(UUID orderId, UUID userId);
     Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
+    Optional<Order> findByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -38,6 +38,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
+    public Optional<Order> findByUserIdAndPlanUnitId(UUID userId, UUID planUnitId) {
+        return orderJpaRepository.findByUserIdAndOrderItems_PlanUnitId(userId, planUnitId);
+    }
+
+    @Override
     public Order save(Order order) {
         return orderJpaRepository.save(order);
     }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 수신하는 이벤트를 추가하고, 이벤트에 대한 후속 처리를 구현했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- PlanUnitParticipantQuitEvent를 수신하고, 상태값을 CANCELLED로 바꾼 뒤, OrderCancelledEvent를 발행하는 로직을 추가했습니다.
- PlanUnitAddParticipantFailedEvent 또는 PlanUnitDeductParticipantEvent를 수신하고 상태값을 CANCELLED로 바꾸는 로직을 추가했습니다.
- userId와 planUnitId로 Order를 조회하는 로직을 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 취소 사유는 임시로 하드코딩된 상태입니다. 추후 이벤트 객체에 필드를 추가하여 변경할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계획의 참여자 탈퇴, 추가 실패, 제거 시 주문을 자동으로 취소하는 기능 추가
  * 이벤트 기반 메시징을 통한 실시간 주문 상태 관리 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/order-service/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->