### PR TITLE
Feat: 스케줄러 도입 및 회원 탈퇴 검증용 내부 API 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/client/PaymentClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/client/PaymentClient.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.order.application.client;
+
+import com.yeoljeong.tripmate.order.application.dto.result.DeletableOrderResult;
+
+import java.util.UUID;
+
+public interface PaymentClient {
+    DeletableOrderResult getDeletablePayment(UUID orderId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/DeletableOrderResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/DeletableOrderResult.java
@@ -1,7 +1,5 @@
 package com.yeoljeong.tripmate.order.application.dto.result;
 
-import java.util.UUID;
-
 public record DeletableOrderResult(
         boolean exists,
         String paymentStatus

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/DeletableOrderResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/DeletableOrderResult.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.order.application.dto.result;
+
+import java.util.UUID;
+
+public record DeletableOrderResult(
+        boolean exists,
+        String paymentStatus
+) { }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
@@ -28,7 +28,7 @@ public record OrderResult(
                         .map(OrderItemResult::from)
                         .toList())
                 .cancelledAt(order.getCancelledAt())
-                .cancelReason(order.getCancelReason())
+                .cancelReason(String.valueOf(order.getCancelReason()))
                 .build();
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/OrderResult.java
@@ -28,7 +28,7 @@ public record OrderResult(
                         .map(OrderItemResult::from)
                         .toList())
                 .cancelledAt(order.getCancelledAt())
-                .cancelReason(String.valueOf(order.getCancelReason()))
+                .cancelReason(order.getCancelReason() != null ? order.getCancelReason().getDescription() : null)
                 .build();
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/WithdrawalCheckResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/dto/result/WithdrawalCheckResult.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.order.application.dto.result;
+
+public record WithdrawalCheckResult(
+        boolean hasActiveData
+) {}

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -20,12 +20,13 @@ import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -152,19 +153,18 @@ public class OrderCommandService {
     }
 
     // 주문 취소 15분 후 스케줄러 작동 로직
-    public void cancelTimeoutOrders() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime timeoutThreshold = now.minusMinutes(PAYMENT_TIMEOUT_MINUTES);
+    public void cancelTimeoutOrders(int batchSize) {
+        LocalDateTime timeoutThreshold = LocalDateTime.now().minusMinutes(PAYMENT_TIMEOUT_MINUTES);
 
-        List<Order> timeoutOrders = orderRepository.findAllByOrderStatusAndCreatedAtBefore(OrderStatus.CREATED, timeoutThreshold);
-
+        Slice<Order> timeoutOrders = orderRepository.findAllByOrderStatusAndCreatedAtBefore(
+                OrderStatus.CREATED, timeoutThreshold, PageRequest.of(0, batchSize));
 
         for (Order order : timeoutOrders) {
             try {
                 DeletableOrderResult payment = paymentClient.getDeletablePayment(order.getId());
 
                 if (!payment.exists()) {
-                    order.cancel(now, OrderCancelReason.PAYMENT_TIMEOUT);
+                    order.cancel(LocalDateTime.now(), OrderCancelReason.PAYMENT_TIMEOUT);
                 }
             } catch (Exception e) {
                 log.warn("[Order] timeout cancel skip: orderId={}", order.getId(), e);

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -4,11 +4,13 @@ import com.yeoljeong.tripmate.event.OrderCancelledEvent;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
 import com.yeoljeong.tripmate.event.enums.OrderTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.application.client.PaymentClient;
 import com.yeoljeong.tripmate.order.application.client.PlanClient;
 import com.yeoljeong.tripmate.order.application.client.ProductClient;
 import com.yeoljeong.tripmate.order.application.dto.command.ApprovalUserCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.CreateOrderCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductCommand;
+import com.yeoljeong.tripmate.order.application.dto.result.DeletableOrderResult;
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.application.port.OrderOutboxRecorder;
 import com.yeoljeong.tripmate.order.domain.enums.OrderCancelReason;
@@ -33,6 +35,7 @@ public class OrderCommandService {
     private final OrderRepository orderRepository;
     private final ProductClient productClient;
     private final PlanClient planClient;
+    private final PaymentClient paymentClient;
     private final OrderOutboxRecorder orderOutboxRecorder;
 
     private static final long PAYMENT_TIMEOUT_MINUTES = 15;
@@ -154,7 +157,11 @@ public class OrderCommandService {
         List<Order> timeoutOrders = orderRepository.findAllByOrderStatusAndCreatedAtBefore(OrderStatus.CREATED, timeoutThreshold);
 
         for (Order order : timeoutOrders) {
-            order.cancelByTimeout(now);
+            DeletableOrderResult payment = paymentClient.getDeletablePayment(order.getId());
+
+            if (!payment.exists()) {
+                order.cancel(now, OrderCancelReason.PAYMENT_TIMEOUT);
+            }
         }
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -12,6 +12,7 @@ import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductComm
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.application.port.OrderOutboxRecorder;
 import com.yeoljeong.tripmate.order.domain.enums.OrderCancelReason;
+import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -32,6 +34,8 @@ public class OrderCommandService {
     private final ProductClient productClient;
     private final PlanClient planClient;
     private final OrderOutboxRecorder orderOutboxRecorder;
+
+    private static final long PAYMENT_TIMEOUT_MINUTES = 15;
 
     public OrderResult createOrder(CreateOrderCommand orderCommand) {
 
@@ -140,6 +144,18 @@ public class OrderCommandService {
         }
 
         order.cancel(LocalDateTime.now(), reason);
+    }
+
+    // 주문 취소 15분 후 스케줄러 작동 로직
+    public void cancelTimeoutOrders() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime timeoutThreshold = now.minusMinutes(PAYMENT_TIMEOUT_MINUTES);
+
+        List<Order> timeoutOrders = orderRepository.findAllByOrderStatusAndCreatedAtBefore(OrderStatus.CREATED, timeoutThreshold);
+
+        for (Order order : timeoutOrders) {
+            order.cancelByTimeout(now);
+        }
     }
 
     private void validateParticipationAvailable(String participationStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -19,6 +19,7 @@ import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -156,11 +158,16 @@ public class OrderCommandService {
 
         List<Order> timeoutOrders = orderRepository.findAllByOrderStatusAndCreatedAtBefore(OrderStatus.CREATED, timeoutThreshold);
 
-        for (Order order : timeoutOrders) {
-            DeletableOrderResult payment = paymentClient.getDeletablePayment(order.getId());
 
-            if (!payment.exists()) {
-                order.cancel(now, OrderCancelReason.PAYMENT_TIMEOUT);
+        for (Order order : timeoutOrders) {
+            try {
+                DeletableOrderResult payment = paymentClient.getDeletablePayment(order.getId());
+
+                if (!payment.exists()) {
+                    order.cancel(now, OrderCancelReason.PAYMENT_TIMEOUT);
+                }
+            } catch (Exception e) {
+                log.warn("[Order] timeout cancel skip: orderId={}", order.getId(), e);
             }
         }
     }

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -11,6 +11,7 @@ import com.yeoljeong.tripmate.order.application.dto.command.CreateOrderCommand;
 import com.yeoljeong.tripmate.order.application.dto.command.OrderableProductCommand;
 import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
 import com.yeoljeong.tripmate.order.application.port.OrderOutboxRecorder;
+import com.yeoljeong.tripmate.order.domain.enums.OrderCancelReason;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
@@ -111,7 +112,7 @@ public class OrderCommandService {
             return;
         }
 
-        order.cancel(LocalDateTime.now(), reason);
+        order.cancel(LocalDateTime.now(), OrderCancelReason.from(reason));
 
         OrderCancelledEvent event = new OrderCancelledEvent(
                 UUID.randomUUID(),
@@ -138,7 +139,7 @@ public class OrderCommandService {
             return;
         }
 
-        order.cancel(LocalDateTime.now(), reason);
+        order.cancel(LocalDateTime.now(), OrderCancelReason.from(reason));
     }
 
     private void validateParticipationAvailable(String participationStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -123,7 +123,7 @@ public class OrderCommandService {
                 order.getId(),
                 order.getUserId(),
                 order.getOrderItems().get(0).getPlanUnitId(),
-                String.valueOf(reason),
+                reason.getDescription(),
                 order.getOrderItems().get(0).getProductInfo().getProductId(),
                 order.getOrderItems().get(0).getProductInfo().getProductName(),
                 order.getOrderItems().get(0).getProductInfo().getScheduleId(),

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -104,7 +104,7 @@ public class OrderCommandService {
     }
 
     // 일정 탈퇴 이벤트 수신 후 동작
-    public void cancelOrderByParticipantQuit(UUID userId, UUID planUnitId, String reason) {
+    public void cancelOrderByParticipantQuit(UUID userId, UUID planUnitId, OrderCancelReason reason) {
         Order order = orderRepository.findByUserIdAndPlanUnitId(userId, planUnitId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
@@ -112,14 +112,14 @@ public class OrderCommandService {
             return;
         }
 
-        order.cancel(LocalDateTime.now(), OrderCancelReason.from(reason));
+        order.cancel(LocalDateTime.now(), reason);
 
         OrderCancelledEvent event = new OrderCancelledEvent(
                 UUID.randomUUID(),
                 order.getId(),
                 order.getUserId(),
                 order.getOrderItems().get(0).getPlanUnitId(),
-                reason,
+                String.valueOf(reason),
                 order.getOrderItems().get(0).getProductInfo().getProductId(),
                 order.getOrderItems().get(0).getProductInfo().getProductName(),
                 order.getOrderItems().get(0).getProductInfo().getScheduleId(),
@@ -131,7 +131,7 @@ public class OrderCommandService {
     }
 
     // 인원 증가 실패 / 인원 감소 이벤트 수신 후 동작
-    public void cancelOrderByPlanUnitParticipantRollback(UUID orderId, String reason) {
+    public void cancelOrderByPlanUnitParticipantRollback(UUID orderId, OrderCancelReason reason) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
@@ -139,7 +139,7 @@ public class OrderCommandService {
             return;
         }
 
-        order.cancel(LocalDateTime.now(), OrderCancelReason.from(reason));
+        order.cancel(LocalDateTime.now(), reason);
     }
 
     private void validateParticipationAvailable(String participationStatus) {

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/query/OrderQueryService.java
@@ -1,10 +1,8 @@
 package com.yeoljeong.tripmate.order.application.service.query;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
-import com.yeoljeong.tripmate.order.application.dto.result.OrderPlanResult;
-import com.yeoljeong.tripmate.order.application.dto.result.OrderResult;
-import com.yeoljeong.tripmate.order.application.dto.result.GetOrderListResult;
-import com.yeoljeong.tripmate.order.application.dto.result.PayableOrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.*;
+import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
@@ -58,5 +56,11 @@ public class OrderQueryService {
         }
 
         return new OrderPlanResult(order.getId(), order.getOrderItems().get(0).getPlanUnitId());
+    }
+
+    public WithdrawalCheckResult getWithdrawalCheck(UUID userId) {
+        boolean exists = orderRepository.existsByUserIdAndOrderStatus(userId, OrderStatus.CREATED);
+
+        return new WithdrawalCheckResult(exists);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/enums/OrderCancelReason.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/enums/OrderCancelReason.java
@@ -2,12 +2,18 @@ package com.yeoljeong.tripmate.order.domain.enums;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
 public enum OrderCancelReason {
-    PLAN_PARTICIPANT_QUIT,
-    PLAN_PARTICIPANT_EXCEEDED,
-    PRODUCT_STOCK_SHORTAGE,
-    PAYMENT_TIMEOUT;
+    PLAN_PARTICIPANT_QUIT("일정 탈퇴"),
+    PLAN_PARTICIPANT_EXCEEDED("일정 인원 초과"),
+    PRODUCT_STOCK_SHORTAGE("상품 재고 부족"),
+    PAYMENT_TIMEOUT("결제 시간 초과");
+
+    private final String description;
 
     public static OrderCancelReason from(String value) {
         if (value == null || value.isBlank()) {

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/enums/OrderCancelReason.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/enums/OrderCancelReason.java
@@ -1,0 +1,23 @@
+package com.yeoljeong.tripmate.order.domain.enums;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
+
+public enum OrderCancelReason {
+    PLAN_PARTICIPANT_QUIT,
+    PLAN_PARTICIPANT_EXCEEDED,
+    PRODUCT_STOCK_SHORTAGE,
+    PAYMENT_TIMEOUT;
+
+    public static OrderCancelReason from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(OrderErrorCode.INVALID_CANCEL_REASON);
+        }
+
+        try {
+            return OrderCancelReason.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(OrderErrorCode.INVALID_CANCEL_REASON);
+        }
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/exception/OrderErrorCode.java
@@ -37,7 +37,9 @@ public enum OrderErrorCode implements ErrorCode {
     PLAN_PARTICIPATION_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "참여되지 않은 일정의 상품은 구매할 수 없습니다."),
     OUTBOX_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "아웃박스 이벤트 직렬화에 실패했습니다."),
     INVALID_TOPIC(HttpStatus.INTERNAL_SERVER_ERROR, "토픽이 유효하지 않습니다."),
-    INVALID_EVENT(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트가 유효하지 않습니다.");
+    INVALID_EVENT(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트가 유효하지 않습니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 내역을 찾을 수 없습니다."),
+    PAYMENT_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 서비스 호출 에러입니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
@@ -115,7 +115,7 @@ public class Order extends BaseAuditEntity {
         this.cancelReason = cancelReason;
     }
 
-    public void cancelByPaymentTimeout(LocalDateTime cancelledAt) {
+    public void cancelByTimeout(LocalDateTime cancelledAt) {
         cancel(cancelledAt, OrderCancelReason.PAYMENT_TIMEOUT);
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
@@ -115,6 +115,10 @@ public class Order extends BaseAuditEntity {
         this.cancelReason = cancelReason;
     }
 
+    public void cancelByPaymentTimeout(LocalDateTime cancelledAt) {
+        cancel(cancelledAt, OrderCancelReason.PAYMENT_TIMEOUT);
+    }
+
     public void delete(UUID userId) {
         super.softDelete();
         this.orderItems.forEach(orderItem -> orderItem.delete(userId));

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/model/Order.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.order.domain.model;
 
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
 import com.yeoljeong.tripmate.order.domain.enums.Country;
+import com.yeoljeong.tripmate.order.domain.enums.OrderCancelReason;
 import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import com.yeoljeong.tripmate.exception.BusinessException;
@@ -50,14 +51,15 @@ public class Order extends BaseAuditEntity {
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "cancel_reason", length = 255)
-    private String cancelReason;
+    private OrderCancelReason cancelReason;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems = new ArrayList<>();
 
     @Builder
-    private Order(UUID userId, OrderStatus orderStatus, LocalDateTime cancelledAt, String cancelReason) {
+    private Order(UUID userId, OrderStatus orderStatus, LocalDateTime cancelledAt, OrderCancelReason cancelReason) {
         this.userId = userId;
         this.orderStatus = orderStatus;
         this.cancelledAt = cancelledAt;
@@ -95,7 +97,7 @@ public class Order extends BaseAuditEntity {
     }
 
     // CREATED -> CANCELLED or COMPLETED -> CANCELLED
-    public void cancel(LocalDateTime cancelledAt, String cancelReason) {
+    public void cancel(LocalDateTime cancelledAt, OrderCancelReason cancelReason) {
         if (this.orderStatus != OrderStatus.CREATED && this.orderStatus != OrderStatus.COMPLETED) {
             throw new BusinessException(OrderErrorCode.INVALID_ORDER_STATUS);
         }

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -31,7 +31,7 @@ public interface OrderRepository {
     boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
 
     // orderStatus와 createdAt 기반 임계값(15분)으로 주문 리스트 조회
-    List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold);
+    Slice<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold, Pageable pageable);
 
     Order save(Order order);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.order.domain.repository;
 
+import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -23,6 +24,9 @@ public interface OrderRepository {
 
     // userId와 planUnitId로 주문 단건 조회
     Optional<Order> findByUserIdAndPlanUnitId(UUID userId, UUID planUnitId);
+
+    // userId와 orderStatus로 주문 조회
+    boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
 
     Order save(Order order);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/domain/repository/OrderRepository.java
@@ -5,6 +5,8 @@ import com.yeoljeong.tripmate.order.domain.model.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,6 +29,9 @@ public interface OrderRepository {
 
     // userId와 orderStatus로 주문 조회
     boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
+
+    // orderStatus와 createdAt 기반 임계값(15분)으로 주문 리스트 조회
+    List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold);
 
     Order save(Order order);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentAdapter.java
@@ -1,0 +1,37 @@
+package com.yeoljeong.tripmate.order.infrastructure.external;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.order.application.client.PaymentClient;
+import com.yeoljeong.tripmate.order.application.dto.result.DeletableOrderResult;
+import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
+import com.yeoljeong.tripmate.order.infrastructure.external.dto.DeletableOrderResponse;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentAdapter implements PaymentClient {
+
+    private final PaymentFeignClient paymentFeignClient;
+
+    @Override
+    public DeletableOrderResult getDeletablePayment(UUID orderId) {
+        try {
+            DeletableOrderResponse deletableOrderResponse = paymentFeignClient.getDeletablePayment(orderId);
+
+            if (deletableOrderResponse == null) {
+                throw new BusinessException(OrderErrorCode.PAYMENT_NOT_FOUND);
+            }
+
+            return new DeletableOrderResult(deletableOrderResponse.exists(), deletableOrderResponse.paymentStatus());
+        } catch (FeignException.NotFound e) {
+            return new DeletableOrderResult(false, null);
+
+        } catch (FeignException e) {
+            throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentAdapter.java
@@ -23,7 +23,7 @@ public class PaymentAdapter implements PaymentClient {
             DeletableOrderResponse deletableOrderResponse = paymentFeignClient.getDeletablePayment(orderId);
 
             if (deletableOrderResponse == null) {
-                throw new BusinessException(OrderErrorCode.PAYMENT_NOT_FOUND);
+                throw new BusinessException(OrderErrorCode.PAYMENT_SERVICE_ERROR);
             }
 
             return new DeletableOrderResult(deletableOrderResponse.exists(), deletableOrderResponse.paymentStatus());

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentFeignClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/PaymentFeignClient.java
@@ -1,0 +1,14 @@
+package com.yeoljeong.tripmate.order.infrastructure.external;
+
+import com.yeoljeong.tripmate.order.infrastructure.external.dto.DeletableOrderResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "payment-service", path = "/internal/payments")
+public interface PaymentFeignClient {
+    @GetMapping("/orders/{orderId}")
+    DeletableOrderResponse getDeletablePayment(@PathVariable("orderId") UUID orderId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/DeletableOrderResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/external/dto/DeletableOrderResponse.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.order.infrastructure.external.dto;
+
+import java.util.UUID;
+
+public record DeletableOrderResponse(
+        UUID orderId,
+        boolean exists,
+        String paymentStatus
+) {}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -6,6 +6,7 @@ import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import com.yeoljeong.tripmate.event.enums.PlanTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
+import com.yeoljeong.tripmate.order.domain.enums.OrderCancelReason;
 import com.yeoljeong.tripmate.order.domain.exception.OrderErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +31,8 @@ public class PlanKafkaConsumer {
     public void consumePlanUnitParticipantQuit(PlanUnitParticipantQuitEvent event, Acknowledgment acknowledgment) {
         log.info("[Order] plan.unit.participant.quit 이벤트 수신: planUnitId={}", event.planUnitId());
 
-        String reason = (event.reason() == null || event.reason().isBlank()) ? "일정 탈퇴" : event.reason();
+        OrderCancelReason reason = (event.reason() == null || event.reason().isBlank())
+                ? OrderCancelReason.PLAN_PARTICIPANT_QUIT : OrderCancelReason.from(event.reason());
 
         try {
             commandService.cancelOrderByParticipantQuit(event.userId(), event.planUnitId(), reason);
@@ -63,7 +65,7 @@ public class PlanKafkaConsumer {
     public void consumePlanUnitAddParticipantFailed(PlanUnitAddParticipantFailedEvent event, Acknowledgment acknowledgment) {
         log.info("[Order] plan.unit.participant.add.failed 이벤트 수신: orderId={}", event.orderId());
 
-        handleParticipantDeductOrAddFailed(event.orderId(), "일정 인원 초과", acknowledgment);
+        handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PLAN_PARTICIPANT_EXCEEDED, acknowledgment);
 
         log.info("[Order] plan.unit.participant.add.failed 이벤트 처리 성공: orderId={}", event.orderId());
     }
@@ -76,12 +78,12 @@ public class PlanKafkaConsumer {
     public void consumePlanUnitDeductParticipant(PlanUnitDeductParticipantEvent event, Acknowledgment acknowledgment) {
         log.info("[Order] plan.unit.participant.deducted 이벤트 수신: orderId={}", event.orderId());
 
-        handleParticipantDeductOrAddFailed(event.orderId(), "상품 재고 부족", acknowledgment);
+        handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PRODUCT_STOCK_SHORTAGE, acknowledgment);
 
         log.info("[Order] plan.unit.participant.deducted 이벤트 처리 성공: orderId={}", event.orderId());
     }
 
-    private void handleParticipantDeductOrAddFailed(UUID orderId, String reason, Acknowledgment acknowledgment) {
+    private void handleParticipantDeductOrAddFailed(UUID orderId, OrderCancelReason reason, Acknowledgment acknowledgment) {
         try {
             commandService.cancelOrderByPlanUnitParticipantRollback(orderId, reason);
             acknowledgment.acknowledge();

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -31,10 +31,10 @@ public class PlanKafkaConsumer {
     public void consumePlanUnitParticipantQuit(PlanUnitParticipantQuitEvent event, Acknowledgment acknowledgment) {
         log.info("[Order] plan.unit.participant.quit 이벤트 수신: planUnitId={}", event.planUnitId());
 
-        OrderCancelReason reason = (event.reason() == null || event.reason().isBlank())
-                ? OrderCancelReason.PLAN_PARTICIPANT_QUIT : OrderCancelReason.from(event.reason());
-
         try {
+            OrderCancelReason reason = (event.reason() == null || event.reason().isBlank())
+                    ? OrderCancelReason.PLAN_PARTICIPANT_QUIT : OrderCancelReason.from(event.reason());
+
             commandService.cancelOrderByParticipantQuit(event.userId(), event.planUnitId(), reason);
             acknowledgment.acknowledge();
 

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.order.infrastructure.persistence.jpa;
 
+import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,4 +14,5 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     Optional<Order> findByIdAndUserId(UUID orderId, UUID userId);
     Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
     Optional<Order> findByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
+    boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -17,5 +17,5 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
     Optional<Order> findByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
     boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
-    List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime createdAt);
+    Slice<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold, Pageable pageable);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +17,5 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
     Slice<Order> findAllByUserId(UUID userId, Pageable pageable);
     Optional<Order> findByUserIdAndOrderItems_PlanUnitId(UUID userId, UUID planUnitId);
     boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus);
+    List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime createdAt);
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/jpa/OrderJpaRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.order.infrastructure.persistence.repositoryImpl;
 
+import com.yeoljeong.tripmate.order.domain.enums.OrderStatus;
 import com.yeoljeong.tripmate.order.domain.model.Order;
 import com.yeoljeong.tripmate.order.domain.repository.OrderRepository;
 import com.yeoljeong.tripmate.order.infrastructure.persistence.jpa.OrderJpaRepository;
@@ -40,6 +41,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public Optional<Order> findByUserIdAndPlanUnitId(UUID userId, UUID planUnitId) {
         return orderJpaRepository.findByUserIdAndOrderItems_PlanUnitId(userId, planUnitId);
+    }
+
+    @Override
+    public boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus) {
+        return orderJpaRepository.existsByUserIdAndOrderStatus(userId, orderStatus);
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,6 +48,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public boolean existsByUserIdAndOrderStatus(UUID userId, OrderStatus orderStatus) {
         return orderJpaRepository.existsByUserIdAndOrderStatus(userId, orderStatus);
+    }
+
+    @Override
+    public List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold) {
+        return orderJpaRepository.findAllByOrderStatusAndCreatedAtBefore(orderStatus, timeoutThreshold);
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/persistence/repositoryImpl/OrderRepositoryImpl.java
@@ -51,8 +51,8 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public List<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold) {
-        return orderJpaRepository.findAllByOrderStatusAndCreatedAtBefore(orderStatus, timeoutThreshold);
+    public Slice<Order> findAllByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime timeoutThreshold, Pageable pageable) {
+        return orderJpaRepository.findAllByOrderStatusAndCreatedAtBefore(orderStatus, timeoutThreshold, pageable);
     }
 
     @Override

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/scheduler/OrderTimeoutScheduler.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/scheduler/OrderTimeoutScheduler.java
@@ -11,9 +11,11 @@ public class OrderTimeoutScheduler {
 
     private final OrderCommandService commandService;
 
+    private static final int TIMEOUT_CANCEL_BATCH_SIZE = 100;
+
     // 매 분 0초마다 확인
     @Scheduled(cron = "0 * * * * *")
     public void cancelPaymentTimeoutOrders() {
-        commandService.cancelTimeoutOrders();
+        commandService.cancelTimeoutOrders(TIMEOUT_CANCEL_BATCH_SIZE);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/scheduler/OrderTimeoutScheduler.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/scheduler/OrderTimeoutScheduler.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.order.infrastructure.scheduler;
+
+import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderTimeoutScheduler {
+
+    private final OrderCommandService commandService;
+
+    // 매 분 0초마다 확인
+    @Scheduled(cron = "0 * * * * *")
+    public void cancelPaymentTimeoutOrders() {
+        commandService.cancelTimeoutOrders();
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/controller/internal/OrderInternalController.java
@@ -3,14 +3,13 @@ package com.yeoljeong.tripmate.order.presentation.controller.internal;
 
 import com.yeoljeong.tripmate.order.application.dto.result.OrderPlanResult;
 import com.yeoljeong.tripmate.order.application.dto.result.PayableOrderResult;
+import com.yeoljeong.tripmate.order.application.dto.result.WithdrawalCheckResult;
 import com.yeoljeong.tripmate.order.application.service.query.OrderQueryService;
+import com.yeoljeong.tripmate.order.presentation.dto.WithdrawalCheckResponse;
 import com.yeoljeong.tripmate.order.presentation.dto.response.OrderPlanResponse;
 import com.yeoljeong.tripmate.order.presentation.dto.response.PayableOrderResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -33,5 +32,12 @@ public class OrderInternalController {
         OrderPlanResult result = queryService.getOrderPlan(orderId);
 
         return new OrderPlanResponse(result.orderId(), result.planUnitId());
+    }
+
+    @GetMapping("/withdrawal-check")
+    public WithdrawalCheckResponse getWithdrawalCheck(@RequestParam("userId") UUID userId) {
+        WithdrawalCheckResult result = queryService.getWithdrawalCheck(userId);
+
+        return new WithdrawalCheckResponse(result.hasActiveData());
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/WithdrawalCheckResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/presentation/dto/WithdrawalCheckResponse.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.order.presentation.dto;
+
+public record WithdrawalCheckResponse(
+        boolean hasActiveData
+) {}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 생성 후 15분 내로 결제가 생성되지 않으면 CANCELLED 상태로 변경하는 스케줄러를 추가했습니다.
- 회원 탈퇴 시 생성 중인 주문이 있는 경우, 탈퇴를 방지하기 위해 검증용 내부 API를 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- OrderCancelReason를 추가하여 주문 취소 사유를 enum으로 관리하도록 수정했습니다.
- 주문 타임아웃(15분) 발생 시 작동하는 스케줄러를 추가했습니다.
  - 매 분 0초에 스케줄러 작동 이후, 15분이 초과하는 CREATED 주문을 조회합니다.
  - 결제 서비스 내부 통신으로 작성된 결제 요청이 있는지 확인합니다.
  - 만약, 생성된 결제가 없다면 주문을 CANCELLED 상태로 변경합니다.
- 회원 서비스에서 사용할 검증용 내부 API를 주가했습니다.
  - CREATED 상태인 주문(진행 중인 주문)이 있는 경우, 탈퇴를 방지하도록 내부 API를 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제가 15분 이내에 완료되지 않은 주문은 자동으로 취소됩니다.
  * 사용자 계정에서 진행 중인 주문 여부를 확인할 수 있는 새로운 기능이 추가되었습니다.
  * 주문 취소 사유 추적 기능이 개선되었습니다.

* **개선 사항**
  * 주문 취소 사유 관리 체계가 강화되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/order-service/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->