### PR TITLE
Feat: 이벤트 역직렬화 코드 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/KafkaPayloadDeserializer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/KafkaPayloadDeserializer.java
@@ -1,0 +1,24 @@
+package com.yeoljeong.tripmate.order.infrastructure.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaPayloadDeserializer {
+
+    private final ObjectMapper objectMapper;
+
+    public <T> T deserialize(String payload, Class<T> clazz) throws JsonProcessingException {
+        try {
+            return objectMapper.readValue(payload, clazz);
+        } catch (JsonProcessingException e) {
+            log.error("[Kafka] 메시지 역직렬화 실패 - class={}, payload={}", clazz.getSimpleName(), payload, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PaymentKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PaymentKafkaConsumer.java
@@ -1,8 +1,8 @@
 package com.yeoljeong.tripmate.order.infrastructure.messaging;
 
+import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.enums.PaymentTopic;
 import com.yeoljeong.tripmate.order.application.service.command.OrderCommandService;
-import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -15,24 +15,28 @@ import org.springframework.stereotype.Component;
 public class PaymentKafkaConsumer {
 
     private final OrderCommandService commandService;
+    private final KafkaPayloadDeserializer payloadDeserializer;
 
     @KafkaListener(
             topics = PaymentTopic.PAYMENT_COMPLETED_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void consumePaymentCompleted(PaymentCompletedEvent event, Acknowledgment acknowledgment) {
-        log.info("[Order] payment.completed 이벤트 수신: orderId={}", event.orderId());
+    public void consumePaymentCompleted(String payload, Acknowledgment acknowledgment) {
 
         try {
+            PaymentCompletedEvent event = payloadDeserializer.deserialize(payload, PaymentCompletedEvent.class);
+
+            log.info("[Order] payment.completed 이벤트 수신: orderId={}", event.orderId());
+
             commandService.completePayment(event.orderId());
             acknowledgment.acknowledge();
 
             log.info("[Order] payment.completed 이벤트 처리 성공: orderId={}", event.orderId());
         } catch (Exception e) {
-            log.error("[Order] payment.completed 이벤트 처리 실패, 재시도 예정: orderId={}, error={}",
-                    event.orderId(), e.getMessage(), e);
-            throw e;
+            log.error("[Order] payment.completed 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
+                    payload, e.getMessage(), e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PaymentKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PaymentKafkaConsumer.java
@@ -34,8 +34,11 @@ public class PaymentKafkaConsumer {
 
             log.info("[Order] payment.completed 이벤트 처리 성공: orderId={}", event.orderId());
         } catch (Exception e) {
-            log.error("[Order] payment.completed 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
-                    payload, e.getMessage(), e);
+            String payloadHash = (payload == null) ? "null" : Integer.toHexString(payload.hashCode());
+            int payloadLength = (payload == null) ? 0 : payload.length();
+
+            log.error("[Order] payment.completed 이벤트 처리 실패, 재시도 예정: payloadHash={}, payloadLength={}, error={}",
+                    payloadHash, payloadLength, e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -1,6 +1,5 @@
 package com.yeoljeong.tripmate.order.infrastructure.messaging;
 
-import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -55,8 +55,11 @@ public class PlanKafkaConsumer {
                     payload, e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
-                    payload, e.getMessage(), e);
+            String payloadHash = (payload == null) ? "null" : Integer.toHexString(payload.hashCode());
+            int payloadLength = (payload == null) ? 0 : payload.length();
+
+            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: payloadHash={}, payloadLength={}, error={}",
+                    payloadHash, payloadLength, e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }
@@ -77,8 +80,11 @@ public class PlanKafkaConsumer {
 
             log.info("[Order] plan.unit.participant.add.failed 이벤트 처리 성공: orderId={}", event.orderId());
         } catch (Exception e) {
-            log.error("[Order] plan.unit.participant.add.failed 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
-                    payload, e.getMessage(), e);
+            String payloadHash = (payload == null) ? "null" : Integer.toHexString(payload.hashCode());
+            int payloadLength = (payload == null) ? 0 : payload.length();
+
+            log.error("[Order] plan.unit.participant.add.failed 이벤트 처리 실패, 재시도 예정: payloadHash={}, payloadLength={}, error={}",
+                    payloadHash, payloadLength, e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }
@@ -99,8 +105,11 @@ public class PlanKafkaConsumer {
 
             log.info("[Order] plan.unit.participant.deducted 이벤트 처리 성공: orderId={}", event.orderId());
         } catch (Exception e) {
-            log.error("[Order] plan.unit.participant.deducted 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
-                    payload, e.getMessage(), e);
+            String payloadHash = (payload == null) ? "null" : Integer.toHexString(payload.hashCode());
+            int payloadLength = (payload == null) ? 0 : payload.length();
+
+            log.error("[Order] plan.unit.participant.deducted 이벤트 처리 실패, 재시도 예정: payloadHash={}, payloadLength={}, error={}",
+                    payloadHash, payloadLength, e.getMessage(), e);
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.order.infrastructure.messaging;
 
+import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
 import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
@@ -22,16 +23,20 @@ import java.util.UUID;
 public class PlanKafkaConsumer {
 
     private final OrderCommandService commandService;
+    private final KafkaPayloadDeserializer payloadDeserializer;
 
     @KafkaListener(
             topics = PlanTopic.PLAN_UNIT_PARTICIPANT_QUIT_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void consumePlanUnitParticipantQuit(PlanUnitParticipantQuitEvent event, Acknowledgment acknowledgment) {
-        log.info("[Order] plan.unit.participant.quit 이벤트 수신: planUnitId={}", event.planUnitId());
+    public void consumePlanUnitParticipantQuit(String payload, Acknowledgment acknowledgment) {
 
         try {
+            PlanUnitParticipantQuitEvent event = payloadDeserializer.deserialize(payload, PlanUnitParticipantQuitEvent.class);
+
+            log.info("[Order] plan.unit.participant.quit 이벤트 수신: planUnitId={}", event.planUnitId());
+
             OrderCancelReason reason = (event.reason() == null || event.reason().isBlank())
                     ? OrderCancelReason.PLAN_PARTICIPANT_QUIT : OrderCancelReason.from(event.reason());
 
@@ -41,19 +46,19 @@ public class PlanKafkaConsumer {
             log.info("[Order] plan.unit.participant.quit 이벤트 처리 성공: userId={}, planUnitId={}", event.userId(), event.planUnitId());
         } catch (BusinessException e) {
             if (isNonRetryable(e)) {
-                log.warn("[Order] plan.unit.participant.quit 이벤트 처리 스킵: userId={}, planUnitId={}", event.userId(), event.planUnitId(), e);
+                log.warn("[Order] plan.unit.participant.quit 이벤트 처리 스킵: payload={}", payload, e);
 
                 acknowledgment.acknowledge();
                 return;
             }
 
-            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: userId={}, planUnitId={}, error={}",
-                    event.userId(), event.planUnitId(), e.getMessage(), e);
+            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
+                    payload, e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: userId={}, planUnitId={}, error={}",
-                    event.userId(), event.planUnitId(), e.getMessage(), e);
-            throw e;
+            log.error("[Order] plan.unit.participant.quit 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
+                    payload, e.getMessage(), e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -62,12 +67,21 @@ public class PlanKafkaConsumer {
             groupId = "${spring.kafka.consumer.group-id}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void consumePlanUnitAddParticipantFailed(PlanUnitAddParticipantFailedEvent event, Acknowledgment acknowledgment) {
-        log.info("[Order] plan.unit.participant.add.failed 이벤트 수신: orderId={}", event.orderId());
+    public void consumePlanUnitAddParticipantFailed(String payload, Acknowledgment acknowledgment) {
 
-        handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PLAN_PARTICIPANT_EXCEEDED, acknowledgment);
+        try {
+            PlanUnitAddParticipantFailedEvent event = payloadDeserializer.deserialize(payload, PlanUnitAddParticipantFailedEvent.class);
 
-        log.info("[Order] plan.unit.participant.add.failed 이벤트 처리 성공: orderId={}", event.orderId());
+            log.info("[Order] plan.unit.participant.add.failed 이벤트 수신: orderId={}", event.orderId());
+
+            handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PLAN_PARTICIPANT_EXCEEDED, acknowledgment);
+
+            log.info("[Order] plan.unit.participant.add.failed 이벤트 처리 성공: orderId={}", event.orderId());
+        } catch (Exception e) {
+            log.error("[Order] plan.unit.participant.add.failed 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
+                    payload, e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
     }
 
     @KafkaListener(
@@ -75,12 +89,22 @@ public class PlanKafkaConsumer {
             groupId = "${spring.kafka.consumer.group-id}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void consumePlanUnitDeductParticipant(PlanUnitDeductParticipantEvent event, Acknowledgment acknowledgment) {
-        log.info("[Order] plan.unit.participant.deducted 이벤트 수신: orderId={}", event.orderId());
+    public void consumePlanUnitDeductParticipant(String payload, Acknowledgment acknowledgment) {
 
-        handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PRODUCT_STOCK_SHORTAGE, acknowledgment);
+        try {
+            PlanUnitDeductParticipantEvent event = payloadDeserializer.deserialize(payload, PlanUnitDeductParticipantEvent.class);
 
-        log.info("[Order] plan.unit.participant.deducted 이벤트 처리 성공: orderId={}", event.orderId());
+            log.info("[Order] plan.unit.participant.deducted 이벤트 수신: orderId={}", event.orderId());
+
+            handleParticipantDeductOrAddFailed(event.orderId(), OrderCancelReason.PRODUCT_STOCK_SHORTAGE, acknowledgment);
+
+            log.info("[Order] plan.unit.participant.deducted 이벤트 처리 성공: orderId={}", event.orderId());
+        } catch (Exception e) {
+            log.error("[Order] plan.unit.participant.deducted 이벤트 처리 실패, 재시도 예정: payload={}, error={}",
+                    payload, e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+
     }
 
     private void handleParticipantDeductOrAddFailed(UUID orderId, OrderCancelReason reason, Acknowledgment acknowledgment) {

--- a/src/main/resources/application-kafka.yaml
+++ b/src/main/resources/application-kafka.yaml
@@ -14,7 +14,7 @@ spring:
       enable-auto-commit: false
 
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
       properties:
         # JSON 역직렬화 허용 패키지
@@ -25,7 +25,7 @@ spring:
 
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
       properties:
         # 메시지 헤더에 클래스 타입 정보 포함


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- Kafka 메시지 payload를 String으로 수신한 뒤, 명시적으로 이벤트 객체로 역직렬화하는 로직을 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 역직렬화 기능을 담은 `KafkaPayloadDeserializer` 클래스를 추가했습니다.
- `OrderKafkaConsumer`에서 event 객체를 받던 부분을 String의 payload로 변경했습니다.
- `OrderKafkaConsumer`에서 `KafkaPayloadDeserializer`를 주입받아 `OrderCancelledEvent`로 역직렬화했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
