### PR TITLE
Feat: 주문 취소 스케줄러 이벤트 발행 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.order.application.service.command;
 
 import com.yeoljeong.tripmate.event.OrderCancelledEvent;
 import com.yeoljeong.tripmate.event.OrderCreatedEvent;
+import com.yeoljeong.tripmate.event.OrderSchedulerCancelledEvent;
 import com.yeoljeong.tripmate.event.enums.OrderTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.order.application.client.PaymentClient;
@@ -165,6 +166,18 @@ public class OrderCommandService {
 
                 if (!payment.exists()) {
                     order.cancel(LocalDateTime.now(), OrderCancelReason.PAYMENT_TIMEOUT);
+
+                    OrderSchedulerCancelledEvent event = new OrderSchedulerCancelledEvent(
+                            UUID.randomUUID(),
+                            order.getUserId(),
+                            order.getOrderItems().get(0).getPlanUnitId(),
+                            order.getOrderItems().get(0).getProductInfo().getProductId(),
+                            order.getOrderItems().get(0).getProductInfo().getScheduleId(),
+                            order.getOrderItems().get(0).getQuantity()
+                    );
+
+                    // 스케줄러 주문 취소 이벤트 outbox에 저장
+                    orderOutboxRecorder.record(OrderTopic.ORDER_SCHEDULER_CANCELLED_TOPIC, event);
                 }
             } catch (Exception e) {
                 log.warn("[Order] timeout cancel skip: orderId={}", order.getId(), e);

--- a/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/application/service/command/OrderCommandService.java
@@ -55,18 +55,18 @@ public class OrderCommandService {
         ApprovalUserCommand approvalUserCommand = planClient.getPlanParticipation(orderCommand.userId(), orderItemCommand.planUnitId());
 
         // 참여 가능 상태인지 검증
-        //validateParticipationAvailable(approvalUserCommand.status());
+        validateParticipationAvailable(approvalUserCommand.status());
 
         // 상품 정보 조회
         OrderableProductCommand productCommand = productClient.getSchedule(orderItemCommand.productId(), orderItemCommand.scheduleId());
 
         // 이미 구매한 단위 일정의 상품인지 확인
-        //validateDuplicateOrder(orderCommand.userId(), orderItemCommand.planUnitId());
+        validateDuplicateOrder(orderCommand.userId(), orderItemCommand.planUnitId());
 
         // 판매 가능 상태인지 검증
-        //validateProductAvailable(productCommand.productStatus());
-        //validateScheduleAvailable(productCommand.scheduleStatus());
-        //validateStock(productCommand.stock(), orderItemCommand.quantity());
+        validateProductAvailable(productCommand.productStatus());
+        validateScheduleAvailable(productCommand.scheduleStatus());
+        validateStock(productCommand.stock(), orderItemCommand.quantity());
 
         Order order = Order.create(
                 orderCommand.userId(),

--- a/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/order/infrastructure/messaging/PlanKafkaConsumer.java
@@ -1,7 +1,7 @@
 package com.yeoljeong.tripmate.order.infrastructure.messaging;
 
 import com.yeoljeong.tripmate.event.PlanUnitAddParticipantFailedEvent;
-import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantEvent;
+import com.yeoljeong.tripmate.event.PlanUnitDeductParticipantByProductEvent;
 import com.yeoljeong.tripmate.event.PlanUnitParticipantQuitEvent;
 import com.yeoljeong.tripmate.event.enums.PlanTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
@@ -90,14 +90,14 @@ public class PlanKafkaConsumer {
     }
 
     @KafkaListener(
-            topics = PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_TOPIC,
+            topics = PlanTopic.PLAN_UNIT_PARTICIPANT_DEDUCTED_BY_PRODUCT_TOPIC,
             groupId = "${spring.kafka.consumer.group-id}",
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void consumePlanUnitDeductParticipant(String payload, Acknowledgment acknowledgment) {
 
         try {
-            PlanUnitDeductParticipantEvent event = payloadDeserializer.deserialize(payload, PlanUnitDeductParticipantEvent.class);
+            PlanUnitDeductParticipantByProductEvent event = payloadDeserializer.deserialize(payload, PlanUnitDeductParticipantByProductEvent.class);
 
             log.info("[Order] plan.unit.participant.deducted 이벤트 수신: orderId={}", event.orderId());
 


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 취소 스케줄러 동작 시 이벤트를 발행하는 로직을 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 스케줄러에 의해 cancel()이 실행된 후, order.scheduler.cancelled(스케줄러 주문 취소 이벤트)를 outbox 테이블에 저장하는 로직을 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 주문 생성 시 참여 가능 여부, 중복 주문, 상품/일정 가용성, 재고 충분성에 대한 유효성 검사가 다시 활성화되었습니다.
  * 타임아웃된 주문 취소 시 관련 이벤트 처리 로직이 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/10jeong/order-service/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->